### PR TITLE
DOCS-1649: move AeroLab docs back to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
+
 # AeroLab
 
-Lab tool for spinning up Aerospike development and testing clusters on Docker or in AWS.
+AeroLab is a tool that creates Aerospike development and testing clusters in Docker or on AWS, streamlining efforts to test cluster configuration options, upgrade procedures, and client
+applications in a controlled development environment.
+
+**NOTE:** AeroLab is intended for local development and testing environments. It is not recommended for production operations. 
 
 ## Releases
 
-Go to the [releases page](https://github.com/aerospike/aerolab/releases) and download the correct binary for your operating system and processor.
+The [releases page](https://github.com/aerospike/aerolab/releases) contains links to current installer
+packages for all the supported backends.
 
 Operating System | Package | Notes
 --- | --- | ---
 macOS | `aerolab-macos-*` | Native macOS binary, compiled for x86_64 and M series ARM chips
 Linux | `aerolab-linux-*` | Native package for Linux (all x86_64 and ARM64 distros)
-Windows | `aerolab-linux-*` | Install and start using WSL2 on Windows
+Windows | `aerolab-linux-*` | Install and start using [WSL2](https://learn.microsoft.com/en-us/windows/wsl/about) on Windows
 
-## Usage instructions
-
-[Official documentation can be found here](https://docs.aerospike.com/tools/aerolab)
 
 ## Supported backends
 
@@ -26,11 +28,32 @@ Windows | `aerolab-linux-*` | Install and start using WSL2 on Windows
 
 ## Routing to the containers using other Docker solutions
 
-Containers cannot be accessed directly by their IPs in certain Docker installations (specifically on macOS and Windows). To work around this, a tunnel can be created to a Docker container as a one-off job. Once done, containers on AeroLab can be accessed directly (e.g. if your node is on 172.17.0.3 port 3000, you can directly seed from that node on the desktop). This is particularly important when starting multi-node clusters, as client code on the desktop must be able to connect to all nodes.
+Containers cannot be accessed directly by their IPs in certain Docker installations (specifically on macOS
+and Windows). To work around this, you can create a tunnel to a Docker container. Once a tunnel container is set up,
+you can access AeroLab containers directly. For example, if your Aerospike node is on 172.17.0.3 port 3000,
+you can directly seed from that node on the desktop. This is particularly important when starting multi-node
+clusters, because client code on the desktop must be able to connect to all nodes.
 
-Follow [this manual](tunnel-container-openvpn/README.md) to set up tunneling for direct container access.
+See the tunnel container [setup instructions](docs/tunnel-container-setup.md) for more information about
+setting up tunneling for direct container access.
 
-IPs of AeroLab containers can be seen by running `aerolab cluster-list`
+You can see the IP addresses of running AeroLab containers with the `aerolab cluster-list` command.
+
+## Table of contents
+
+[Getting started](docs/getting-started.md)
+
+[AeroLab on AWS](docs/aws-setup.md)
+
+[Help commands](docs/usage/help.md)
+
+[Usage examples](docs/usage/index.md)
+
+[Deploying clients](docs/deploy_clients/index.md)
+
+[REST API](docs/rest-api.md)
+
+[Utility scripts](docs/utility_scripts/index.md)
 
 ## Changelog
 

--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -1,0 +1,209 @@
+[Docs home](../README.md)
+
+## Sub-topics:
+
+[Custom VPC setup notes](vpc.md)
+
+[Partitioning disks in AWS](partitioner/partition-disks.md)
+
+[Use all disks for a namespace](partitioner/all-disks.md)
+
+[Use all NVME disks for a namespace](partitioner/all-nvme-disks.md)
+
+[Create Partitioning for Two Namespaces](partitioner/two-namespaces-nvme.md)
+
+[Configure Shadow Devices](partitioner/with-shadow.md)
+
+[Partition NVME and EBS for All-Flash Storage](partitioner/with-allflash.md)
+
+
+# AeroLab on AWS
+
+## Prerequisites
+
+### Create a credentials file
+
+There are two ways to create a credentials file:
+
+#### Using aws-cli
+
+1. Download and install [aws-cli](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+2. Run the command `aws configure`
+
+#### Manually
+
+Create the `~/.aws` directory, inside the directory create two files:
+
+`~/.aws/credentials`
+
+```toml
+[default]
+aws_access_key_id = KEYID
+aws_secret_access_key = SECRETKEY
+```
+
+`~/.aws/config`
+
+```toml
+[default]
+region = DEFAULT_REGION_TO_USE
+```
+
+### OPTIONAL: Configure an AWS account
+
+You can use the default AWS subnets and security groups and
+AeroLab will create the required security groups with minimal permissions required.
+
+:::note
+If you do not specify a VPC, AeroLab will create it, together with default subnets.
+:::
+
+### Security Groups
+
+AeroLab clusters require a security group. The following rules allow full connectivity:
+
+1. Create a security group (sg-xxxx) with the rule to allow all outbound (default) and inbound: port 22(tcp) from any IP address.
+
+2. Edit the security group (sg-xxxx) and add a rule to allow all inbound on all ports coming from itself (source: sg-xxxx).
+
+If you plan to deploy AMS or other clients:
+
+1. Create a security group (sg-yyyy) with a rule to allow all outbound (default) and allow inbound from any IP adress to the following TCP ports: 22, 3000, 8888, 8080.
+
+2. Edit the security group (sg-yyyy), adding 2 rules:
+   a) Allow all ports from self source (sg-yyyy).
+   b) Allow all ports from server source (sg-xxxx).
+
+3. Edit the security group (sg-xxxx), and add a rule allowing all ports from the client source security group (sg-yyyy).
+
+Use (sg-xxxx) for clusters and (sg-yyyy) for client machines.
+
+### Subnets
+
+If creating a new subnet and/or VPC, configure the VPC and Subnet such that:
+* the instances will have automatically assigned public DNS
+* the instances will have automatically assigned public IP addresses
+
+### Configure the AWS backend with AeroLab
+
+The most basic configuration is:
+
+```bash
+aerolab config backend -t aws [-d /path/to/tmpdir/for-aerolab/to/use]
+```
+
+To specify a custom location where SSH keys are stored and override the
+default AWS region configuration, extra parameters may be supplied:
+
+```bash
+aerolab config backend -t aws -p /PATH/TO/KEYS -r AWS_REGION [-d /path/to/tmpdir/for-aerolab/to/use]
+```
+
+## Deploy an Aerospike cluster in AWS
+
+Extra parameters are required when working with the `aws` backend as opposed to the `docker` backend.
+
+Executing `aerolab cluster create help` once the backend has been selected displays the relevant options.
+
+## Notes on AWS and custom VPCs
+
+If you don't use the default VPC, certain conditions must be met when configuring a custom one.
+Refer to the [VPC reference](vpc.md) for more information.
+
+### Examples:
+
+#### First subnet in default VPC/AZ:
+
+```bash
+aerolab cluster create -n testcluster -c 3 -m mesh -I t3a.medium -E 20
+```
+
+#### First subnet in default VPC for a given AZ:
+
+```bash
+aerolab cluster create -n testcluster -c 3 -m mesh -I t3a.medium -E 20 -U us-east-1a
+```
+
+#### Specify custom security group and subnet:
+
+```bash
+aerolab cluster create -n testcluster -c 3 -m mesh -I t3a.medium -E 20 -S sg-03430d698bffb44a3 -U subnet-06cc8a834647c4cc3
+```
+
+#### Lock security-groups so that machines are only accessible from the AeroLab IP address:
+
+```bash
+# default VPC
+aerolab config aws lock-security-groups
+# custom VPC
+aerolab config aws lock-security-groups -v vpc-...
+```
+
+#### Lock security-groups so that machines are only accessible from a given IP range:
+
+```bash
+# default VPC
+aerolab config aws lock-security-groups --ip 1.2.3.4/32
+# custom VPC
+aerolab config aws lock-security-groups --ip 1.2.3.4/32 -v vpc-...
+```
+
+### Destroy cluster:
+```bash
+aerolab cluster destroy -f -n testcluster
+```
+
+#### Destroy aerolab-managed security groups:
+
+```bash
+# default VPC
+aerolab config aws delete-security-groups
+# custom VPC
+aerolab config aws delete-security-groups -v vpc-...
+```
+
+## Other commands
+
+All commands are supported on both `aws` and `docker` backends and should behave exactly the same.
+
+## Working with multiple regions
+
+You can work with multiple regions by switching the backend:
+
+```bash
+aerolab config backend -t aws -r eu-west-1
+# ...commands...
+aerolab config backend -t aws -r us-east-1
+# ...commands...
+```
+
+Alternatively, if you frequently use multiple regions, you can have
+multiple configuration files:
+
+```bash
+# create a config called us.conf
+AEROLAB_CONFIG_FILE=us.conf
+aerolab config backend -t aws -r us-east-1
+
+# create a config called eu.conf
+AEROLAB_CONFIG_FILE=eu.conf
+aerolab config backend -t aws -r eu-west-1
+
+# since eu is the exported region variable, default commands execute against it
+aerolab cluster create
+aerolab attach shell -- asadm -e info
+
+# execute an ad-hoc command on another region
+AEROLAB_CONFIG_FILE=us.conf aerolab cluster create
+
+# keep running in eu region
+aerolab cluster destroy
+```
+
+## Note on shared AWS accounts and KeyPairs
+
+AeroLab creates and destroys SSH key pairs as needed. However, if
+a particular cluster is created by user X, user Y can only access
+the cluster if user X shares their key pair for that cluster.
+
+By default, keys are stored in `${HOME}/aerolab-keys`.

--- a/docs/deploy_clients/elasticsearch.md
+++ b/docs/deploy_clients/elasticsearch.md
@@ -1,0 +1,53 @@
+[Docs home](../../README.md)
+
+# Deploy the Elasticsearch connector for Aerospike
+
+
+1. Create an Aerospike cluster:
+
+```bash
+# aws
+aerolab cluster create -c 2 -I t3a.medium -n mycluster
+# docker
+aerolab cluster create -c 2 -n mycluster
+```
+
+2. Create an Elasticsearch cluster, with Aerospike connector preinstalled on each node:
+
+```bash
+# aws
+aerolab client create elasticsearch -c 2 -I t3a.large -n myes
+# docker - limit each ES node to 4g ram
+aerolab client create elasticsearch -c 2 -r 4 -n myes
+```
+
+3. Configure the Aerospike cluster to ship records to the connector:
+
+```bash
+aerolab xdr connect -S mycluster -D myes -c
+```
+
+### Testing
+
+1. Insert 2000 test records:
+
+```bash
+aerolab data insert -n mycluster -a 1 -z 2000
+```
+
+2. Query Elasticsearch:
+
+   - Run `aerolab client list` to get your Elasticsearch server's IP address.
+   - Navigate to the Elasticsearch IP address, port `9200` in your browser to explore the data from Elasticsearch.
+
+For best results, use the FireFox web browser. It has a built-in JSON format explorer,
+as well as support for self-signed certificates once the warning is acknowledged.
+
+Example URLs:
+
+- Show summary: `https://ELASTICIP:9200/test/_search`
+- Show up to 1000 records: `https://ELASTICIP:9200/test/_search?size=1000`
+- Show records where bin name `mybin` has value `binvalue`: `https://ELASTICIP:9200/test/_search?q=mybin:binvalue`
+- Show up to 1000 records from set name `myset`: `https://ELASTICIP:9200/test/_search?size=1000&q=metadata.set:myset`
+
+Replace *`ELASTICIP`* with the IP address of your Elasticsearch server.

--- a/docs/deploy_clients/index.md
+++ b/docs/deploy_clients/index.md
@@ -1,0 +1,79 @@
+[Docs home](../../README.md)
+
+## Sub-topics
+
+[Launch a VS Code client VM with AeroLab](vscode.md)
+
+[Deploy a Trino server](trino.md)
+
+[Deploy a Jupyter Notebook VM with AeroLab](jupyter.md)
+
+[Deploy the Elasticsearch connector for Aerospike](elasticsearch.md)
+
+[Deploy a Rest Gateway](restgw.md)
+
+# Deploying clients with AeroLab
+
+
+## Client command
+
+```
+Usage:
+  aerolab [OPTIONS] client [command]
+
+Available commands:
+  create     Create new client machines
+  configure  (re)configure some clients, such as ams
+  list       List client machine groups
+  start      Start a client machine group
+  stop       Stop a client machine group
+  grow       Grow a client machine group
+  destroy    Destroy client(s)
+  attach     symlink to: attach client
+  help       Print help
+```
+
+## Client create command - supported clients
+
+```
+Usage:
+  aerolab [OPTIONS] client create [command]
+
+Available commands:
+  base           simple base image
+  tools          aerospike-tools
+  ams            prometheus and grafana for AMS; for exporter see: cluster add exporter
+  jupyter        launch a jupyter IDE client
+  vscode         launch a VSCode IDE client
+  trino          launch a Trino server (use 'client attach trino' to get Trino shell)
+  elasticsearch  deploy elasticsearch with the es connector for aerospike
+  rest-gateway   deploy a rest-gateway client machine
+```
+
+## Get help for a given client type
+
+```bash
+aerolab client create base help
+aerolab client create tools help
+```
+
+## Example
+
+### Create three base client machines and grow the client group by three tools client machines
+
+```bash
+aerolab client create base -n myclients -c 3
+aerolab client grow tools -n myclients -c 3
+```
+
+### List clients
+
+```bash
+aerolab client list
+```
+
+### Destroy clients
+
+```bash
+aerolab client destroy -n myclients -f
+```

--- a/docs/deploy_clients/jupyter.md
+++ b/docs/deploy_clients/jupyter.md
@@ -1,0 +1,65 @@
+[Docs home](../../README.md)
+
+# Deploy a Jupyter Notebook VM with AeroLab
+
+
+Jupyter is a web-based interface for interactive testing and
+development of code. It is intended for testing purposes only.
+
+Supported Jupyter kernels are: `go,python,dotnet,java,node`
+
+## Help pages
+
+```
+aerolab client create jupyter help
+```
+
+## Create a Jupyter client machine with all kernels
+
+```
+aerolab client create jupyter -n jupyter
+```
+
+## Create a Jupyter client machine with Go and Python kernels only
+
+```
+aerolab client create jupyter -n jupyter -k go,python
+```
+
+## Add dotnet kernel to existing Jupyter client
+
+```
+aerolab client create jupyter -n jupyter -k dotnet
+```
+
+## Connect
+
+First get IP from:
+
+```
+aerolab client list
+```
+
+Then, in the browser, navigate to:
+
+```
+http://IP:8888
+```
+
+## Seed IPs
+
+Use the `-s` switch  when creating a Jupyter client to make the creation process auto-fill the IP addresses in the example code with the cluster IP addresses for seeding.
+
+If you haven't used the `-s` switch when creating a jupyter client, remember to adjust the seed IP address inside the jupyter GUI when editing your code, or you won't be able to connect.
+
+## Connectivity notes on Docker Desktop
+
+If you use Docker Desktop, you cannot access the containers directly from your host machine.
+In this case, when running the `create` commands above, add the `-e 8888:8888` switch to expose port 8888 to the
+host. Then access the Jupyter server in your browser using `http://127.0.0.1:8888`.
+
+Example:
+
+```
+aerolab client create jupyter -n jupyter -e 8888:8888
+```

--- a/docs/deploy_clients/restgw.md
+++ b/docs/deploy_clients/restgw.md
@@ -1,0 +1,40 @@
+[Docs home](../../README.md)
+
+# Deploy a Rest Gateway
+
+
+Use the [Aerospike REST Gateway](https://developer.aerospike.com/client/rest)
+to communicate with an Aerospike cluster via RESTful requests.
+
+1. Create a test cluster with three nodes
+
+```
+aerolab cluster create -n bob -c 3
+```
+
+2. Insert test data into namespace `test`
+
+```
+aerolab data insert -z 10000 -u 5 -n bob -m test
+```
+
+3. Deploy a Rest Gateway client
+
+```
+aerolab client create rest-gateway -n myrest -C bob
+```
+
+4. Attach to the Rest Gateway machine and execute a scan
+
+```
+aerolab attach client -n myrest
+$ curl http://localhost:8080/v1/scan/test
+```
+
+### Notes
+
+* To adjust the seed IP or connect with a username and password at a later time,
+  use the `aerolab client configure rest-gateway` command. Append `help` at the
+  end of the command for usage information.
+* You can adjust all settings, including the startup, by changing the startup script
+  on the Rest Gateway machine, located at `/opt/autoload/01-restgw.sh`.

--- a/docs/deploy_clients/trino.md
+++ b/docs/deploy_clients/trino.md
@@ -1,0 +1,43 @@
+[Docs home](../../README.md)
+
+# Deploy a Trino server
+
+
+Launch a [Trino](https://trino.io/) server and shell, and query your Aerospike cluster with SQL.
+
+## Get the Aerospike cluster IPs
+
+```bash
+aerolab cluster list
+```
+
+## Create the Trino client machine
+
+Use `172.17.0.3:3000` as the Aerospike server seed IP:PORT
+
+```bash
+aerolab client create trino -n trino -s 172.17.0.3:3000
+```
+
+## Change which Aerospike cluster the Trino server communicates with
+
+Use `172.17.0.4:3000` as seed IP:PORT
+
+```bash
+aerolab client configure trino -n trino -s 172.17.0.4:3000
+```
+
+## Attach to the Trino shell
+In this example we'll connect the shell to the Aerospike cluster's test
+namespace.
+
+```bash
+aerolab client attach trino -n trino -m test
+```
+
+## Attach to the Trino shell - the long way
+This example demonstrates passing the Trino shell command to the Trino client
+machine.
+```bash
+aerolab client attach -n trino -- su - trino -c "bash ./trino --server 127.0.0.1:8080 --catalog aerospike --schema test"
+```

--- a/docs/deploy_clients/vscode.md
+++ b/docs/deploy_clients/vscode.md
@@ -1,0 +1,43 @@
+[Docs home](../../README.md)
+
+# Launch a VS Code client VM with AeroLab
+
+
+AeroLab supports installing a VS Code IDE in a browser, complete with Java, Go, Python and C# language clients and code examples.
+
+## Install VS Code with Aerolab
+
+### If your host talks directly to your containers or AWS instances
+
+```bash
+aerolab client create vscode -n vscode
+```
+
+### If using Docker Desktop
+
+```bash
+aerolab client create vscode -n vscode -e 8080:8080
+```
+
+## Accessing the IDE through the browser
+
+### If your host talks directly to your containers or AWS instances
+
+1. Get the IP of the client machine using `aerolab client list`.
+2. Visit the following URL in the browser: `http://<IP>:8080`
+
+### If using Docker Desktop
+
+Visit `http://127.0.0.1:8080`
+
+## Install, choosing only some language clients
+
+```bash
+aerolab client create vscode -n somename -k go,python
+```
+
+## See help to list supported language clients
+
+```bash
+aerolab client create vscode help
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,172 @@
+# Getting started With AeroLab
+
+## One-time setup
+
+Follow either the Docker or AWS instructions below, depending on the backend you use.
+You can use both backends at once, and use AeroLab commands on either one.
+
+### Docker instructions
+
+1. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) on your machine.
+
+2. Start Docker. To make sure it's running, run `docker version` at the command line.
+
+3. Configure disk, RAM,and CPU resources. In the Docker tray-icon, go to `Preferences`. Configure the required disk, RAM and CPU resources. At least 2 cores and 2 GB of RAM is recommended for a single-node cluster.
+
+### AWS
+
+Follow [this manual](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) to install the AWS CLI.
+
+Run `aws configure` to configure basic access to AWS.
+
+### Download AeroLab from the releases page
+
+The [releases page](https://github.com/aerospike/aerolab/releases) has links to installers for all the
+supported platforms
+
+Note that AeroLab can deploy Aerospike instances on both ARM64 and x86_64 architectures,
+regardless of which AeroLab binary you use.
+
+Operating System | CPU | File | Comments
+--- | --- | --- | ---
+macOS | ALL | `aerolab-macos-VERSION.pkg` | multi-arch AeroLab installer for macOS
+macOS | M1 or M2 | `aerolab-macos-arm64-VERSION.zip` | single executable binary in a zip file
+macOS | Intel CPU | `aerolab-macos-amd64-VERSION.zip` | single executable binary in a zip file
+Linux (generic) | arm | `aerolab-linux-arm64-VERSION.zip` | single executable binary in a zip file
+Linux (generic) | Intel/AMD | `aerolab-linux-amd64-VERSION.zip` | single executable binary in a zip file
+Linux (centos) | arm | `aerolab-linux-arm64-VERSION.rpm` | RPM for installing on centos/rhel-based distros
+Linux (centos) | Intel/AMD | `aerolab-linux-x86_64-VERSION.rpm` | RPM for installing on centos/rhel-based distros
+Linux (ubuntu) | arm | `aerolab-linux-arm64-VERSION.deb` | DEB for installing on ubuntu/debian-based distros
+Linux (ubuntu) | Intel/AMD | `aerolab-linux-amd64-VERSION.deb` | DEB for installing on ubuntu/debian-based distros
+
+### Install
+
+Installation with the provided installer files is the recommended method. After download, run the executable
+and the `aerolab` command will become available.
+
+Alternatively, you can perform a manual installation by downloading the relevant `zip` file, unpacking it,
+and then moving the unpacked `aerolab` binary to `/usr/local/bin/`. Remember to run `chmod +x` on the `aerolab`
+binary to make it executable.
+
+### First run
+
+Running `aerolab` at the command line outputs a help page asking for backend configuration.
+
+```bash
+% aerolab
+
+Create a config file and select a backend first using one of:
+
+$ aerolab config backend -t docker [-d /path/to/tmpdir/for-aerolab/to/use]
+$ aerolab config backend -t aws [-r region] [-p /custom/path/to/store/ssh/keys/in/] [-d /path/to/tmpdir/for-aerolab/to/use]
+
+Default file path is ${HOME}/.aerolab.conf
+
+To specify a custom configuration file, set the environment variable:
+   $ export AEROLAB_CONFIG_FILE=/path/to/file.conf
+```
+
+### Configuring defaults
+
+You can change the default configuration with the `aerolab config defaults` command. If you
+change the defaults, the new values are used as defaults. You can still change the
+configuration at runtime by specifying command line switches.
+
+Command | Description
+--- | ---
+`aerolab config defaults help` | print help for using the defaults command
+`aerolab config defaults` | print all defaults
+`aerolab config defaults -o` | print only the defaults that have been adjusted in the config file
+`aerolab config defaults -k '*Features*'` | print all defaults containing the word `Features`
+`aerolab config defaults -k '*.HeartbeatMode' -v mesh` | adjust `HeartbeatMode` default to `mesh` for all available commands
+
+### Getting started: configuration basics
+
+It's a good idea to configure the basics so you don't have to use command line switches each time.
+
+If you wish to use a custom features file, run the following command:
+`aerolab config defaults -k '*FeaturesFilePath' -v /path/to/features.conf`
+
+If using multiple feature file versions, a directory containining those may be specified: `aerolab config defaults -k '*FeaturesFilePath' -v /path/to/features/dir/`
+
+### AeroLab on Windows with WSL2
+
+1. Go to `Docker Desktop` -> `Settings` -> `General`.  Select `Use the WSL 2 based engine`
+2. Under `Resources -> WSL Integration`, select the virtual machine(s) you want to give access to Docker
+3. Stop `WSL` by executing `wsl --shutdown`
+4. Restart your `WSL` Linux virtual machine
+5. Fix permissions: `sudo chmod 777 /var/run/docker.sock` - this needs to be done every time Docker is restarted, or alternatively `aerolab` will have to be run with `sudo` each time
+
+### Shell completion
+
+To enable shell completion, run one (or both) of:
+
+```
+aerolab completion zsh
+aerolab completion bash
+```
+
+## Basic usage
+
+### Deploy a cluster called `testme` with 5 nodes
+```
+aerolab cluster create --name=testme --count=5
+```
+
+### Attach to node 2 in that cluster
+```
+aerolab attach shell --name=testme --node=2
+root@node:/ $ service aerospike status
+Aerospike running
+root@node:/ $ service aerospike stop
+Stopping Aerospike ... OK
+root@node:/ $ service aerospike start
+Starting Aerospike ... OK
+root@node:/ $ exit
+```
+
+### Run `asadm info` command on node 2
+```
+$ aerolab attach shell --name=testme --node=2 -- asadm -e info
+$ aerolab attach asadm --name=testme --node=2 -- -e info
+```
+
+### Run `asinfo` on all nodes
+```
+$ aerolab attach asinfo --name=testme --node=all -- -v service
+$ aerolab attach shell --name=testme --node=all -- asinfo -v service
+$ aerolab attach shell --name=testme --node=<node-expander-syntax> -- asinfo -v service
+```
+
+### Node Expander
+
+For commands accepting a list of nodes, the list is a comma-separated list of:
+* `ALL` - all nodes
+* `-X` - negative number - exclude node
+* `X` - positive number - include node
+* `X-Y` - range of nodes to include
+
+For example:
+* `ALL,-5` - all nodes except for node 5
+* `1-10,-5,12` - nodes 1-10, except node 5, and also node 12
+
+### Destroy the cluster, force stopping
+```
+$ aerolab cluster destroy --name=testme -f
+```
+
+### Get help on commands list
+
+```
+aerolab help
+aerolab {command} help
+aerolab {command} {subcommand} help
+```
+
+### Configuration file generator
+
+AeroLab can generate a basic `aerospike.conf` file by running:
+
+````
+aerolab conf generate
+````

--- a/docs/partitioner/all-disks.md
+++ b/docs/partitioner/all-disks.md
@@ -1,0 +1,29 @@
+[Docs home](../../README.md)
+
+# Use all disks for a namespace
+
+
+1. Create a cluster:
+
+```
+aerolab cluster create -n clusterName -c 2 -I r5ad.large -E 20,30,30
+```
+
+2. `blkdiscard` and prepare the cluster:
+
+```
+aerolab cluster partition create -n clusterName
+```
+
+3. Configure Aerospike to use devices for `test` namespace:
+
+```
+aerolab cluster partition conf -n clusterName --namespace=test --filter-partitions=0 --configure=device
+```
+
+4. Restart Aerospike:
+
+```
+aerolab aerospike stop -n clusterName
+aerolab aerospike start -n clusterName
+```

--- a/docs/partitioner/all-nvme-disks.md
+++ b/docs/partitioner/all-nvme-disks.md
@@ -1,0 +1,30 @@
+[Docs home](../../README.md)
+
+
+# Use all NVME disks for a namespace
+
+
+1 Create a cluster:
+
+```
+aerolab cluster create -n clusterName -c 2 -I r5ad.4xlarge
+```
+
+2. `blkdiscard` and prepare the cluster:
+
+```
+aerolab cluster partition create -n clusterName --filter-type=nvme
+```
+
+3. Configure Aerospike to use devices for `test` namespace:
+
+```
+aerolab cluster partition conf -n clusterName --namespace=test --filter-type=nvme --filter-partitions=0 --configure=device
+```
+
+4. Restart Aerospike:
+
+```
+aerolab aerospike stop -n clusterName
+aerolab aerospike start -n clusterName
+```

--- a/docs/partitioner/partition-disks.md
+++ b/docs/partitioner/partition-disks.md
@@ -1,0 +1,41 @@
+# Partitioning disks in AWS
+
+
+AeroLab supports automated disk discovery and partitioning. The partitioner has 4 options:
+
+Commands | Description
+--- | ---
+`cluster partition list` | List disks and partitions on all/chosen nodes.
+`cluster partition create` | Create partitions on disks. This will also remove any previous partitions and filesystems on the chosen disks.
+`cluster partition mkfs` | Make filesystems on chosen partitions, automatically mount in `/mnt`, and add the mountpoint to `fstab`.
+`cluster partition conf` | Adjust Aerospike configuration to reflect newly created partitions. Supports devices, shadow devices and all-flash devices.
+
+## Filters
+
+Each command accepts filters where disks/partitions to affect can be chosen. The filters are exclusive, meaning that for a disk/partition to be selected, it must satisfy all filters.
+
+:::note
+Any disks with partitions mounted to `/` or `/boot*` are excluded from any listing or partition/disk number assignment and are not displayed or considered by AeroLab.
+:::
+
+Filter | Description
+--- | ---
+`--filter-type` | Filter by disk type. Available options are `nvme` or `ebs`. If set, selects all NVME disks, or all EBS disks. Commands which don't specify a disk type apply to all disks.
+`--filter-disks` | Filter by disk number. AeroLab assigns disk numbers by disk name, in alphabetical order.
+`--filter-partitions` | Filter by partition number. AeroLab assigns each partition a number, starting from 1 for each disk.
+
+### Filter examples
+
+* `--filter-type=nvme`: Take action on all NVME disks.
+* `--filter-disks=1-3`: Take action on disks 1-3.
+* `--filter-partitions=1,2`: Take action on partitions 1 and 2 on all disks.
+* `--filter-type=nvme --filter-partitions=1,2`: Take action on partitions 1 and 2 only on NVME disks.
+* `--filter-disks=1-3 --filter-partitions=1`: Take action on partition 1 on disks 1-3.
+
+## Usage Examples
+
+* [Use all disks for a namespace](all-disks.md)
+* [Use all NVME disks for a namespace](all-nvme-disks.md)
+* [Partition each NVME into 4 partitions and use 2 for each of the two namespaces](two-namespaces-nvme.md)
+* [Partition NVME and EBS and configure shadow devices for a namespace](with-shadow.md)
+* [Partition NVME and EBS, use all partitions for namespace, with first nvme partition of each nvme disk for all-flash](with-allflash.md)

--- a/docs/partitioner/two-namespaces-nvme.md
+++ b/docs/partitioner/two-namespaces-nvme.md
@@ -1,0 +1,31 @@
+[Docs home](../../README.md)
+
+
+# Create Partitioning for Two Namespaces
+
+
+1. Create a cluster:
+
+```
+aerolab cluster create -n clusterName -c 2 -I r5ad.4xlarge
+```
+
+2. `blkdiscard` and partition, 25% disk space on each partition:
+
+```
+aerolab cluster partition create -n clusterName --filter-type=nvme -p 25,25,25,25
+```
+
+3. Configure Aerospike to use devices for `test` and `bar` namespaces:
+
+```
+aerolab cluster partition conf -n clusterName --namespace=test --filter-type=nvme --filter-partitions=1,2 --configure=device
+aerolab cluster partition conf -n clusterName --namespace=bar --filter-type=nvme --filter-partitions=3,4 --configure=device
+```
+
+4. Restart Aerospike:
+
+```
+aerolab aerospike stop -n clusterName
+aerolab aerospike start -n clusterName
+```

--- a/docs/partitioner/with-allflash.md
+++ b/docs/partitioner/with-allflash.md
@@ -1,0 +1,61 @@
+[Docs home](../../README.md)
+
+
+# Partition NVME and EBS for All-Flash Storage
+
+
+This example presents a more complicated scenario, in which:
+- 2 NVME devices exist, to be partitioned into 5 partitions each:
+    - First partition of each NVME disk should be used for all-flash storage.
+    - Remaining 4 partitions of each NVME disk should be used for device storage.
+- 4 EBS devices exist, to be used as shadows for the 8 total NVME partitions.
+  - Each EBS must consist of 2 partitions.
+
+1. Create a cluster.
+
+```
+aerolab cluster create -n clusterName -c 2 -I r5ad.4xlarge -E 20,30,30,30,30
+```
+
+2. `blkdiscard` and partition NVME: 20% disk space on each partition.
+
+```
+aerolab cluster partition create -n clusterName --filter-type=nvme -p 20,20,20,20,20
+```
+
+3. `blkdiscard` and partition ebs: 50% disk space on each partition.
+
+```
+aerolab cluster partition create -n clusterName --filter-type=ebs -p 50,50
+```
+
+4. Configure Aerospike to use devices for `test` namespace, except first partition:
+
+```
+aerolab cluster partition conf -n clusterName --namespace=test --filter-type=nvme --configure=device --filter-partitions=2-5
+```
+
+5. Configure EBS to be used as shadow devices, all partitions:
+
+```
+aerolab cluster partition conf -n clusterName --namespace=test --filter-type=ebs --configure=shadow
+```
+
+6. Create a filesystem on partition 1 of each NVME disk, for all-flash:
+
+```
+aerolab cluster partition mkfs -n clusterName --filter-type=nvme --filter-partitions=1
+```
+
+7. Create or update all-flash Aerospike configuration on nodes:
+
+```
+aerolab cluster partition conf -n clusterName --filter-type=nvme --namespace=test --configure=allflash --filter-partitions=1
+```
+
+8. Restart Aerospike:
+
+```
+aerolab aerospike stop -n clusterName
+aerolab aerospike start -n clusterName
+```

--- a/docs/partitioner/with-shadow.md
+++ b/docs/partitioner/with-shadow.md
@@ -1,0 +1,46 @@
+[Docs home](../../README.md)
+
+
+# Configure Shadow Devices
+
+
+This example presents a scenario, in which:
+- 2 NVME devices exist, to be partitioned into 4 partitions each.
+- 8 EBS devices exist, to be used as shadows for the 8 total NVME partitions.
+
+1. Create a cluster:
+
+```
+aerolab cluster create -n clusterName -c 2 -I r5ad.4xlarge -E 20,30,30,30,30,30,30,30,30
+```
+
+2. `blkdiscard` and partition NVME: 25% disk space on each partition.
+
+```
+aerolab cluster partition create -n clusterName --filter-type=nvme -p 25,25,25,25
+```
+
+3. prepare EBS by zeroing out the first 8MiB as required by Aerospike:
+
+```
+aerolab cluster partition create -n clusterName --filter-type=ebs
+```
+
+4. Configure Aerospike to use devices for `test` namespace
+
+```
+aerolab cluster partition conf -n clusterName --namespace=test --filter-type=nvme --configure=device
+```
+
+5. Configure EBS to be used as shadow devices, no partitions:
+
+```
+aerolab cluster partition conf -n clusterName --namespace=test --filter-type=ebs --filter-partitions=0 --configure=shadow
+```
+
+6. Restart Aerospike:
+
+```
+aerolab aerospike stop -n clusterName
+aerolab aerospike start -n clusterName
+```

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1,0 +1,147 @@
+[Docs home](../README.md)
+
+# REST API
+
+
+AeroLab has basic support for a simplified implementation of a REST API.
+
+## Usage
+
+### Start REST API
+
+```
+$ aerolab rest-api
+2022/10/19 15:42:24 Listening on 127.0.0.1:3030...
+```
+
+A custom IP:PORT can be specified instead of the defaults:
+
+```
+$ aerolab rest-api -l 0.0.0.0:3000
+2022/10/19 16:56:23 Listening on 0.0.0.0:3000...
+```
+
+Authentication and TLS are not currently supported. If you require authentication,
+use a webserver in front of AeroLab.
+
+### API usage
+
+AeroLab APIs require a path representing the CLI commands. Once a command is selected via the
+URI, parameters are provided in the payload in JSON format.
+
+The API is fully explorable and documented within `aerolab` itself.
+
+While all the command-line features are supported by the API in full, the response messages
+are in the same format as would be provided by the CLI (plain-text).
+
+If an error occurs during the execution of a given command, either `500 InternalServerError`
+or `400 BadRequest`, an HTTP response code is returned to the caller. On successful
+execution, `200 OK` will be returned.
+
+Try the following to explore the API and available options.
+
+### Help pages
+
+#### Get a list of top-level commands:
+
+```
+$ curl -X POST http://127.0.0.1:3030/help
+
+Command     | Description
+------------+--------------------------------------------------
+/config     | Show or change aerolab configuration
+/cluster    | Create and manage Aerospike clusters and nodes
+/aerospike  | Aerospike daemon controls
+/client     | Create and manage Client machine groups
+/attach     | Attach to a node and run a command
+/net        | Firewall and latency simulation
+/conf       | Manage Aerospike configuration on running nodes
+/tls        | Create or copy TLS certificates
+/data       | Insert/delete Aerospike data
+/template   | Manage or delete template images
+/installer  | List or download Aerospike installer versions
+/logs       | show or download logs
+/files      | Upload/Download files to/from clients or clusters
+/xdr        | Mange clusters' xdr configuration
+/roster     | Show or apply strong-consistency rosters
+/version    | Print AeroLab version
+/completion | Install shell completion scripts
+/rest-api   | Launch HTTP rest API
+/help       | Print help
+/quit       | Exit aerolab rest service
+```
+
+#### Get a list of subcommands within the cluster command
+
+```
+$ curl -X POST http://127.0.0.1:3030/cluster/help
+
+Command          | Description
+-----------------+----------------------------------
+/cluster/create  | Create a new cluster
+/cluster/list    | List clusters
+/cluster/start   | Start cluster
+/cluster/stop    | Stop cluster
+/cluster/grow    | Add nodes to cluster
+/cluster/destroy | Destroy cluster
+/cluster/add     | Add features to clusters, ex: ams
+```
+
+#### Get a list of available JSON payload parameters for calling the `destroy` subcommand
+
+Since the `/cluster/destroy` subcommand is an actual execution command
+(will execute an action) and does not have any subcommands of its own, executing
+`help` here prints both the accepted JSON payload (with default parameters already filled in)
+and a table explaining what each parameter represents.
+
+```
+$ curl -X POST http://127.0.0.1:3030/cluster/destroy/help
+
+=== JSON payload with default values ===
+{
+  "ClusterName": "mydc",
+  "Nodes": "",
+  "Docker": {
+    "Force": false
+  }
+}
+
+=== Payload Parameter descriptions ===
+Key          | Kind    | Description
+-------------+---------+---------------------------------------------------------------
+ClusterName  | string  | Cluster names, comma separated OR 'all' to affect all clusters
+Nodes        | string  | Nodes list, comma separated. Empty=ALL
+Docker.Force | boolean | force stop before destroy
+```
+
+### Examples
+
+#### Create a new 4-node cluster name `bob`
+
+```
+curl -X POST http://127.0.0.1:3030/cluster/create -d '{"ClusterName":"bob","NodeCount":4}'
+```
+
+#### List root directory contents
+
+```
+curl -X POST http://127.0.0.1:3030/attach/shell -d '{"ClusterName":"bob","Tail":["ls","/"]}'
+```
+
+#### List clusters, standard table format
+
+```
+curl -X POST http://127.0.0.1:3030/cluster/list
+```
+
+#### List clusters, provide json output
+
+```
+curl -X POST http://127.0.0.1:3030/cluster/list -d '{"Json":true}'
+```
+
+#### Destroy the cluster
+
+```
+curl -X POST http://127.0.0.1:3030/cluster/destroy -d '{"ClusterName":"bob","Docker":{"Force":true}}'
+```

--- a/docs/tunnel-container-setup.md
+++ b/docs/tunnel-container-setup.md
@@ -1,0 +1,58 @@
+# Tunnel Container Setup
+
+## Description
+
+This container will auto-build and then auto-run every time you start Docker.
+
+The container allows the host macOS/Windows system to access all containers directly
+using the `172.17.0.0/24` IP addresses. This makes it possible to run a client application
+on your macOS/Windows system and connect to the cluster that is running in the containers
+(deployed in Docker using AeroLab).
+
+## Initial container deployment
+
+1. Use the `docker ps` command to check that no other Docker containers are running.
+2. Run the following commands from the terminal command line:
+
+```bash
+git clone https://github.com/aerospike/aerolab
+cd aerolab/tunnel-container-openvpn/build-run
+chmod 755 *sh && ./RUNME.sh
+```
+
+## Initial host system setup
+
+### macOS
+
+1. Download [Tunnelblick](https://tunnelblick.net/), install and start it.
+2. From the taskbar menu, click on `VPN Details`.
+3. In the Finder, navigate to the `aerolab/tunnel-container-openvpn/build-run/keys` directory.
+4. Drag and drop the file `client.conf` to the `Configurations` pane of the Tunnelblick window.
+5. Choose either `Only Me` or `All Users`.
+6. Close the Tunnelblick window.
+
+### Windows
+1. Download [OpenVPN Connect](https://openvpn.net/client-connect-vpn-for-windows/), install and start it.
+2. Click the Plus button.
+3. Click `Import from file`.
+4. Rename `aerolab/tunnel-container-openvpn/build-run/keys/client.conf` to `aerolab/tunnel-container-openvpn/build-run/keys/client.ovpn`.
+5. Drag and drop the file `aerolab/tunnel-container-openvpn/build-run/keys/client.ovpn` into the OpenVPN window and click `Add`.
+6. Save and close the window.
+
+## Usage following installation
+
+Once Docker is started on macOS/Windows, click on the `OpenVPN Connect` or `Tunnelblick` icon
+in the taskbar, and click `Connect`.
+
+NOTE: on first run you may get two warnings, one about DNS not changing and one about IPs
+not changing. This is normal, as we are not tunneling anything apart from/to Docker traffic.
+Click on `Do not warn ...` on both warning windows and click `OK`.
+
+## Technical details
+
+This procedure installs OpenVPN Server (with all the bells and whistles of
+configuration), generates CA/server/client certificates and exports the certificates to
+the host machine. The server configuration has a route to force the Docker IP address range of
+`172.17.0.0/16` to go through this VPN tunnel. Tunnelblick and OpenVPN Connect are GUIs
+for OpenVPN, allowing you to connect to the OpenVPN server in a container from the OpenVPN
+client on your host machine and allowing a `172.17.0.0/16` route to traverse through.

--- a/docs/usage/advanced/all-flash.md
+++ b/docs/usage/advanced/all-flash.md
@@ -1,0 +1,46 @@
+[Docs home](../../../README.md)
+
+# Deploy an all-flash namespace
+
+
+### Configuring All Flash with AeroLab
+
+#### Prepare a template for the All Flash namespace
+
+The following example is a snippet of the configuration template you need. Pay attention to the
+`index-type` sub-section. Your template must be a complete aerospike.conf - see the `templates/`
+directory in this repo for full examples.
+
+```
+namespace bar {
+        replication-factor 1
+        memory-size 4G
+        default-ttl 0
+
+        partition-tree-sprigs 256
+
+        index-type flash {
+                mount /mnt
+                mounts-size-limit 5G
+        }
+
+        storage-engine device {
+                file /opt/aerospike/data/bar.dat
+                filesize 10G
+                data-in-memory false
+        }
+}
+```
+
+#### Deploy AeroLab with the All Flash template
+
+Deploying AeroLab with your All Flash template requires a privileged container. In this example
+you will be deploying a cluster with three nodes, using mesh:
+
+```bash
+aerolab cluster create -n someName -c 3 --privileged
+```
+
+That's it, the cluster will be created, with the primary index of the namespace stored on `/mnt`.
+Note that in this example no mount points or file systems are created. We are simply using a
+pre-existing `/mnt` directory on the root filesystem, which works well for testing purposes.

--- a/docs/usage/advanced/custom-build.md
+++ b/docs/usage/advanced/custom-build.md
@@ -1,0 +1,56 @@
+[Docs home](../../../README.md)
+
+# Custom Aerospike build
+
+
+## Method 1: Use a prebuilt installer tarball
+
+### Download the custom build and name it according to the following example convention:
+
+```
+aerospike-server-enterprise-5.7.0.27-ubuntu20.04.x86_64.tgz
+aerospike-server-enterprise-6.2.0.6-amazon2.x86_64.tgz
+aerospike-server-enterprise-6.2.0.6-ubuntu20.04.x86_64.tgz
+aerospike-server-enterprise-6.2.0.6-centos8.x86_64.tgz
+```
+
+In other words, the file needs to be called: `aerospike-server-enterprise-${VERSION}-${OS}${OS_VER}.${ARCH}.tgz`
+
+Version can be any Aerospike version (4 digits separated by dots) with optionally another dot and an RC file designation, for example: `6.4.0.0.rc1`
+
+The operating system must be one of the following: `centos`, `amazon`, `ubuntu`. The operating system version must be the version for which this build is made.
+
+The architecture is either `x86_64` or `arm64`.
+
+### Run Aerospike
+
+Use `aerolab` as normal, specifying the correct version.
+
+For example, given a file `aerospike-server-enterprise-6.2.0.6.rc1-ubuntu20.04.x86_64.tgz`, install Aerospike as:
+
+```
+aerolab cluster create -d ubuntu -i 20.04 -v 6.2.0.6.rc1
+```
+
+The version is already downloaded, so AeroLab will automatically use it instead of trying to download it.
+
+## Method 2: providing a custom binary
+
+### Create an Aerospike cluster (2 example nodes)
+
+```
+aerolab cluster create -d ubuntu -i 20.04 -v 6.2.0.6 -c 2 -s n
+```
+
+### Upload a custom Aerospike binary
+
+```
+aerolab files upload asd /usr/bin/asd
+aerolab attach shell -l all -- chmod 755 /usr/bin/asd
+```
+
+### Start Aerospike
+
+```
+aerolab aerospike start
+```

--- a/docs/usage/advanced/encryption.md
+++ b/docs/usage/advanced/encryption.md
@@ -1,0 +1,34 @@
+[Docs home](../../../README.md)
+
+# Encryption at rest
+
+
+Each namespace in an Aerospike Database Enterprise Edition cluster can be
+[configured with Encryption at Rest](/server/operations/configure/security/encryption-at-rest).
+
+### Create a cluster with the encryption at rest config template
+In this example you will create a three node Aerospike cluster using the encryption at
+rest [template](https://github.com/aerospike/aerolab/templates/encryption-at-rest.conf), and provide
+a feature file as well.
+
+```bash
+$ aerolab cluster create -c 3 -o templates/encryption-at-rest.conf -f /path/to/feature.conf -s n
+```
+
+### Generate an encryption key on your machine
+```bash
+# mac:
+$ head -c 256 /dev/urandom >key.dat
+# linux/WSL2:
+$ head --bytes 256 /dev/urandom >key.dat
+```
+
+### Copy your encryption key to the cluster nodes
+```bash
+$ aerolab files upload key.dat /etc/aerospike/key.dat
+```
+
+### Start the Aerospike Database
+```bash
+$ aerolab aerospike start
+```

--- a/docs/usage/advanced/index.md
+++ b/docs/usage/advanced/index.md
@@ -1,0 +1,13 @@
+[Docs home](../../../README.md)
+
+# Advanced AeroLab Commands
+
+## Sub-topics
+
+[Deploy an all-flash namespace](all-flash.md)
+
+[Encryption at rest](encryption.md)
+
+[Simulate raw block storage](loop-dev.md)
+
+[Custom Aerospike build](custom-build.md)

--- a/docs/usage/advanced/loop-dev.md
+++ b/docs/usage/advanced/loop-dev.md
@@ -1,0 +1,130 @@
+[Docs home](../../../README.md)
+
+# Simulate raw block storage
+
+
+## Use a loop device to simulate raw block storage
+
+When deploying Aerospike Database on Docker with AeroLab, you can simulate `device` block storage using a loop device.
+
+In this example you will deploy the following setup:
+
+* An Aerospike EE 4.9 cluster called 'source' being an XDR source for a namespace _bar_. The namespace has its data on file storage and XDR on a separately mounted file system.
+* An Aerospike EE 4.9 cluster called 'destination' being the XDR destination for the namespace _bar_, with its data on a `device` storage engine. This device storage uses a loop device mounted in privileged mode.
+
+### Deploy the clusters
+
+Deploy clusters, naming them `source` and `destination`, with two nodes in each, using the `bar-file-store.conf` template. Do not start Aerospike automatically, and enter privileged mode.
+
+```bash
+$ aerolab cluster create -n source -c 2 -s n -o templates/bar-file-store.conf --privileged -v 4.9.0.32
+```
+
+```bash
+$ aerolab cluster create -n destination -c 2 -s n -o templates/bar-file-store.conf --privileged -v 4.9.0.32
+```
+
+### Configure the destination cluster
+
+#### Create raw empty files to use as storage 1024MB (1GB)
+
+```bash
+aerolab attach shell -n destination -l all -- /bin/bash -c 'dd if=/dev/zero of=/store$NODE.raw bs=1M count=1024'
+```
+
+#### Loop-mount the files as devices
+
+**Note:** loop device interfaces are global and shared by all containers, as they belong to the Docker host. Therefore they must be given unique names.
+Since AeroLab exposes the environment variable `$NODE` to the shell when running the `attach shell` command, you can make use of it to create unique names.
+
+```bash
+aerolab attach shell -n destination -l all -- /bin/bash -c 'losetup -f /store$NODE.raw'
+```
+
+#### Perform changes in the aerospike.conf file using sed
+
+Change the configuration from `file` to `device` storage,  noting the /dev/loopX device created by `losetup` - you need to find the one that is for this container and use it.
+
+```bash
+aerolab attach shell -n destination -l all -- /bin/bash -c 'sed -i "s~file /opt/aerospike/data/bar.dat~device $(losetup --raw |grep store$NODE.raw |cut -d " " -f 1)~g" /etc/aerospike/aerospike.conf'
+```
+
+Remove `filesize 1G`
+
+```bash
+aerolab attach shell -n destination -l all -- /bin/bash -c 'sed -i "s~filesize 1G~~g" /etc/aerospike/aerospike.conf'
+```
+
+Change `data-in-memory` from `true` to `false`
+
+```bash
+aerolab attach shell -n destination -l all -- /bin/bash -c 'sed -i "s~data-in-memory true~data-in-memory false~g" /etc/aerospike/aerospike.conf'
+```
+
+#### Start Aerospike on the destination cluster and check the logs on node 1
+
+```bash
+aerolab aerospike start -n destination
+
+aerolab attach shell -n destination -- cat /var/log/aerospike.log
+```
+
+### Connect the source cluster to destination cluster on namespace bar
+
+```bash
+$ aerolab xdr connect -s source -d destination -m bar
+```
+
+### Configure raw file with a file system, and mount it for use with XDR
+
+#### Create a 100MB file
+
+```bash
+aerolab attach shell -n source -l all -- dd if=/dev/zero of=/xdr.raw bs=1M count=100MB
+```
+
+#### Create a filesystem in the file
+
+```bash
+aerolab attach shell -n source -l all -- mkfs.ext4 /xdr.raw
+```
+
+#### Mount
+
+Mount `/xdr/raw` as `/opt/aerospike/xdr` directory
+
+```bash
+aerolab attach shell -n source -l all -- mount /xdr.raw /opt/aerospike/xdr
+```
+
+#### Start the source Aerospike cluster, and print the logs of node 1
+
+```bash
+aerolab aerospike start -n source
+
+aerolab attach shell -n source -- cat /var/log/aerospike.log
+```
+
+### ESSENTIAL cleanup
+
+Because loop devices are essentially kernel-level devices, you must stop the Aerospike cluster and clean up the loop device.
+
+**Note:** if you forget this step, stopping Docker and starting it will clear the loop device interfaces on its own anyway.
+
+```bash
+aerolab aerospike stop -n destination
+
+aerolab attach shell -n destination -- /bin/bash -c 'losetup --raw |grep store |grep raw |cut -d " " -f 1 |while read line; do losetup -d $line; done'
+```
+
+#### Destroy the Docker containers
+
+```bash
+aerolab cluster destroy -f -n source
+aerolab cluster destroy -f -n destination
+```
+
+### Caveats
+
+* Because a loop device is essentially set on the kernel level of the host, stopping and starting Docker will remove loop devices. This setup is only good for testing. If you stop the Docker host, it's easier to redo this manually, including setting up loop devices from scratch.
+* The loop devices are visible to any privileged container, and any privileged container can access them. E.g. running `losetup -a` on the source cluster nodes would show those loop devices from destination nodes

--- a/docs/usage/basic/aerospike.md
+++ b/docs/usage/basic/aerospike.md
@@ -1,0 +1,37 @@
+[Docs home](../../../README.md)
+
+# Aerospike database commands
+
+AeroLab's `aerospike` commands deal with starting and stopping the Aerospike
+server daemon ([asd](https://docs.aerospike.com/server/operations/manage/aerospike))
+on the Aerospike Database cluster nodes.
+
+### Start an Aerospike cluster
+
+```bash
+aerolab aerospike start -n mycluster
+```
+
+### Stop an Aerospike cluster
+
+```bash
+aerolab aerospike stop -n mycluster
+```
+
+### Restart an Aerospike cluster
+
+```bash
+aerolab aerospike restart -n mycluster
+```
+
+### Upgrade node 2 of the Aerospike cluster in-place
+
+```bash
+aerolab aerospike upgrade -n mycluster -l 2 -v 5.7.0.6
+```
+
+### Restart node 2 of the Aerospike cluster
+
+```bash
+aerolab aerospike restart -n mycluster -l 2
+```

--- a/docs/usage/basic/clients.md
+++ b/docs/usage/basic/clients.md
@@ -1,0 +1,67 @@
+[Docs home](../../../README.md)
+
+# Deploy clients
+
+
+### Client command
+
+```
+Usage:
+  aerolab [OPTIONS] client [command]
+
+Available commands:
+  create     Create new client machines
+  configure  (re)configure some clients, such as ams
+  list       List client machine groups
+  start      Start a client machine group
+  stop       Stop a client machine group
+  grow       Grow a client machine group
+  destroy    Destroy client(s)
+  attach     symlink to: attach client
+  help       Print help
+```
+
+### Client create command - supported clients
+
+```
+Usage:
+  aerolab [OPTIONS] client create [command]
+
+Available commands:
+  base           simple base image
+  tools          aerospike-tools
+  ams            prometheus and grafana for AMS; for exporter see: cluster add exporter
+  jupyter        launch a jupyter IDE client
+  vscode         launch a VSCode IDE client
+  trino          launch a Trino server (use 'client attach trino' to get Trino shell)
+  elasticsearch  deploy elasticsearch with the es connector for aerospike
+  rest-gateway   deploy a rest-gateway client machine
+```
+
+### Get help for a given client type
+
+```bash
+aerolab client create base help
+aerolab client create tools help
+```
+
+### Example
+
+#### Create three base client machines and grow the client group by three tools client machines
+
+```bash
+aerolab client create base -n myclients -c 3
+aerolab client grow tools -n myclients -c 3
+```
+
+#### List clients
+
+```bash
+aerolab client list
+```
+
+#### Destroy clients
+
+```bash
+aerolab client destroy -n myclients -f
+```

--- a/docs/usage/basic/cluster.md
+++ b/docs/usage/basic/cluster.md
@@ -1,0 +1,87 @@
+[Docs home](../../../README.md)
+
+# Cluster commands
+
+AeroLab `cluster` commands deal with provisioning and destroying Aerospike
+machines, whether they're on Docker containers or AWS VMs.
+
+### Create a two-node Aerospike cluster
+
+#### Use the newest version of Aerospike Database
+
+```bash
+aerolab cluster create -c 2 -n mycluster
+```
+
+#### Pick a specific version of Aerospike
+
+```bash
+aerolab cluster create -c 2 -n mycluster -v 4.9.0.32
+```
+
+### Stop a cluster
+
+```bash
+aerolab cluster stop -n mycluster
+```
+
+### Start an existing cluster
+
+```bash
+aerolab cluster start -n mycluster
+```
+
+### List clusters, templates and IP addresses
+
+```bash
+aerolab cluster list
+```
+
+### Add two more nodes to an existing cluster
+
+```bash
+aerolab cluster grow -c 2 -n mycluster
+```
+
+### Fix the mesh heartbeat configuration in an Aerospike cluster
+
+```bash
+aerolab conf fix-mesh -n mycluster
+```
+
+### Destroy the cluster
+
+```bash
+aerolab cluster destroy -n mycluster -f
+```
+
+### Create a two-node cluster with a custom version, and passing in an aerospike.conf file
+
+```bash
+aerolab cluster create -c 2 -n mycluster -v 4.9.0.32 -o my-aerospike-conf-template.conf
+```
+
+### Stop cluster node 2
+
+```bash
+aerolab cluster stop -n mycluster -l 2
+```
+
+### Destroy cluster node 2
+
+```bash
+aerolab cluster destroy -n mycluster -l 2
+```
+
+### Destroy a template image
+
+```bash
+aerolab cluster list
+aerolab template destroy -v 4.9.0.32 -d all -i all
+```
+
+### Destroy all AeroLab template images
+
+```bash
+aerolab template destroy -v all -d all -i all
+```

--- a/docs/usage/basic/custom-start.md
+++ b/docs/usage/basic/custom-start.md
@@ -1,0 +1,24 @@
+[Docs home](../../../README.md)
+
+# Custom startup scripts
+
+
+Both `cluster create` and `client create` support installing a startup script via their command line parameters.
+
+### Cluster create
+
+The available options are to install an early startup script and a late stop script.
+
+The startup script will run before Aerospike starts and the stop script will run after Aerospike stops.
+
+### Client create
+
+The startup script will run every time a client machine is started.
+
+### Custom options
+
+Both clients and clusters will also attempt to start any and all scripts from `/opt/autoload`.
+
+This directory may not exist by default, but once it is created, any files within it will be executed by bash on cluster/client startup.
+
+These scripts start last, after everything else has started. Some `aerolab` features make use of this, such as `exporter` start script and `ams` client start scripts.

--- a/docs/usage/basic/data.md
+++ b/docs/usage/basic/data.md
@@ -1,0 +1,27 @@
+[Docs home](../../../README.md)
+
+# Insert and delete data
+
+While `asbench` can be used to benchmark Aerospike clusters and perform specific workloads, AeroLab provides a simple way to insert and delete data with a more lab-test approach.
+
+### Insert data
+
+Insert 100K records into namespace `test`, set `myset`
+
+```bash
+aerolab data insert -m test -s myset -a 1 -z 100000
+```
+
+### Durable-delete data
+
+Delete only the first 50K records
+
+```bash
+aerolab data delete -m test -s myset -a 1 -z 50000 -D
+```
+
+### Note on features
+
+For specific needs, explore `aerolab data insert help` and `aerolab data delete help`
+
+The `data insert` function has a large number of features, including selection of bin names and values to insert data, read-after-write option, TLS and auth support, TTL support and an option to force data load only to a specific set of nodes or partitions.

--- a/docs/usage/basic/get-logs.md
+++ b/docs/usage/basic/get-logs.md
@@ -1,0 +1,34 @@
+[Docs home](../../../README.md)
+
+# Logging
+
+
+Read more about [Configuring Log Files](/server/operations/configure/logging/configure_log_files.md)
+
+### Logs from a Docker container
+
+```bash
+aerolab logs get -n mydc
+ls logs/
+```
+
+### Logs from journald on AWS
+
+```bash
+aerolab logs get -n mydc --journal
+ls logs/
+```
+
+### Logs from a custom log file location
+
+```bash
+aerolab logs get -n mydc -p /var/log/aerospike/aerospike.log
+ls logs/
+```
+
+### Showing logs instead of downloading
+
+To show rather than fetch the logs, replace `get` with `show` in the examples
+above.
+
+Add the command line switch `-f` or `--follow` to tail the logs.

--- a/docs/usage/basic/index.md
+++ b/docs/usage/basic/index.md
@@ -1,0 +1,35 @@
+[Docs home](../../../README.md)
+
+# Basic AeroLab Commands
+
+## Sub-topics
+
+[Cluster commands](cluster.md)
+
+[Aerospike database commands](aerospike.md)
+
+[Node attach commands](node-attach.md)
+
+[Insert and delete data](data.md)
+
+[Deploy clients](clients.md)
+
+[Upload and download files](updown.md)
+
+[Logging](get-logs.md)
+
+[Cross-datacenter replication](xdr.md)
+
+[Network control commands](net.md)
+
+[TLS setup](tls.md)
+
+[Custom startup scripts](custom-start.md)
+
+[Limit cluster resource use](limits.md)
+
+[Deploy a rack-aware cluster](racks.md)
+
+[Deploy a rack-aware cluster with strong consistency](racks-sc.md)
+
+[Strong consistency](strong.md)

--- a/docs/usage/basic/limits.md
+++ b/docs/usage/basic/limits.md
@@ -1,0 +1,27 @@
+[Docs home](../../../README.md)
+
+# Limit cluster resource use
+
+
+### Note on RAM limit and swap limit
+
+* `ram-limit` is the amount of RAM memory the node can use
+* `swap-limit` is the amount of RAM+SWAP memory the node can use
+* as such, to set 300MiB RAM and 100MiB swap, `ram-limit=300m`, `swap-limit=400m` (300MiB + 100MiB)
+
+### Instructions
+
+#### Create a two node cluster, giving each node 0.5 of a CPU and 500MiB of RAM + 100MiB of swap access
+```bash
+$ ./aerolab cluster create -c 2 --cpu-limit=0.5 --ram-limit=500m --swap-limit=600m
+```
+
+#### Grow the cluster by one node with a two core limit, 1GiB of RAM and no swap
+```bash
+$ ./aerolab cluster grow -c 1 --cpu-limit=2 --ram-limit=1g --swap-limit=1g
+```
+
+#### Grow the cluster by one node with a 0.1 CPU limit, 1GiB of RAM and unlimited swap
+```bash
+$ ./aerolab cluster grow -c 1 --cpu-limit=0.1 --ram-limit=1g
+```

--- a/docs/usage/basic/net.md
+++ b/docs/usage/basic/net.md
@@ -1,0 +1,70 @@
+[Docs home](../../../README.md)
+
+# Network control commands
+
+
+AeroLab's `net` commands allow you to simulate problems in inter-node and
+inter-cluster networking.
+
+### Block a port
+
+Block node 1 in cluster `dc1` from talking on port `3000` to node 2 of cluster `dc2`; simulate packet loss through `drop` instead of `reject`.
+
+```bash
+aerolab net block -s dc1 -l 1 -d dc2 -i 2 -t drop -p 3000
+```
+
+### List network blocks
+
+```bash
+aerolab net list
+```
+
+### Unblock the previous network block
+
+```bash
+aerolab net unblock -s dc1 -l 1 -d dc2 -i 2 -t drop -p 3000
+```
+
+### Redo the network block, then trigger random packet loss
+
+Same block as before, this time randomly dropping 3% of all packets
+
+```bash
+aerolab net block -s dc1 -l 1 -d dc2 -i 2 -t drop -p 3000 -M random -P 0.03
+```
+
+### Remove the network block
+
+```bash
+aerolab net unblock -s dc1 -l 1 -d dc2 -i 2 -t drop -p 3000 -M random -P 0.03
+```
+
+### Implement packet loss or packet latency
+
+Switch | Meaning
+--- | ---
+s | Source cluster name
+l | Source node list
+d | Destination cluster name
+i | Destination node list
+a | action; set|del|delall|show
+p | Latency
+L | Packet loss count
+R | Max link speed
+
+```bash
+aerolab net loss-delay -s dc1 -l 1 -d dc2 -i 2 -a set -p 100ms -L 10% -R 1024Kbps
+```
+
+### Show netowrk loss rules
+
+```bash
+aerolab net loss-delay -s dc1 -l 1 -d dc2 -l 2 -a show
+```
+
+### Delete all network loss rules between dc1 and dc2
+
+```bash
+aerolab net loss-delay -s dc1 -l 1,2,3 -d dc2 -i 1,2,3 -a del
+```

--- a/docs/usage/basic/node-attach.md
+++ b/docs/usage/basic/node-attach.md
@@ -1,0 +1,55 @@
+[Docs home](../../../README.md)
+
+# Node attach commands
+
+
+AeroLab's `attach` commands give you shell access and direct tool access to the
+Aerospike Database cluster nodes.
+
+### Attach to the shell of cluster node 2
+
+```bash
+aerolab attach shell -n mycluster -l 2
+```
+
+### Attach to the shell of cluster node 2 and execute a command
+
+```bash
+aerolab attach shell -n mycluster -l 2 -- ls /
+```
+
+### Run AQL on cluster node 2
+
+```bash
+aerolab attach aql -n mycluster -l 2
+```
+
+### Run AQL on cluster node 2 with a command
+
+```bash
+aerolab attach aql -n mycluster -l 2 -- -c "show sets"
+```
+
+### Run asinfo on cluster node 1 with a command
+
+```bash
+aerolab attach asinfo -n mycluster -l 1 -- -v service
+```
+
+### Run asadm on cluster node 2
+
+```bash
+aerolab attach asadm -n mycluster -l 2
+```
+
+### Run asadm on cluster node 2 with a command
+
+```bash
+aerolab attach asadm -n mycluster -l 2 -- -e "info"
+```
+
+### Run AQL on all nodes
+
+```bash
+aerolab attach aql -n mycluster -l all -- -c "show sets"
+```

--- a/docs/usage/basic/racks-sc.md
+++ b/docs/usage/basic/racks-sc.md
@@ -1,0 +1,35 @@
+[Docs home](../../../README.md)
+
+# Deploy a rack-aware cluster with strong consistency
+
+
+AeroLab simplifies deploying a [rack-aware](/server/operations/configure/network/rack-aware)
+Aerospike Database cluster in [strong consistency mode](/server/architecture/consistency).
+
+### Create a 6-node Aerospike cluster, do not start `aerospike`
+
+```bash
+aerolab cluster create -c 6 -s n -o SC-TEMPLATE-FILE.CONF
+```
+
+## Assign rack-id 1 to first three nodes, all namespaces
+
+Do not re-roster with strong consistency yet.
+
+```bash
+aerolab conf rackid -l 1-3 -i 1 --no-roster
+```
+
+## Assign rack-id 2 to the next three nodes, all namespaces
+
+This time, apply the strong consistency roster and start the cluster.
+
+```bash
+aerolab conf rackid -l 4-6 -i 2
+```
+
+## Confirm the cluster is working
+
+```bash
+aerolab attach asadm -- -e info
+```

--- a/docs/usage/basic/racks.md
+++ b/docs/usage/basic/racks.md
@@ -1,0 +1,37 @@
+[Docs home](../../../README.md)
+
+# Deploy a rack-aware cluster
+
+
+AeroLab makes it easy to deploy a [rack-aware](/server/operations/configure/network/rack-aware)
+Aerospike Database cluster.
+
+### Create a 6-node Aerospike cluster, do not start `aerospike`
+
+```bash
+aerolab cluster create -c 6 -s n
+```
+
+### Assign rack-id 1 to first three nodes, all namespaces
+
+```bash
+aerolab conf rackid -l 1-3 -i 1 --no-restart
+```
+
+### Assign rack-id 2 to the next three nodes, all namespaces
+
+```bash
+aerolab conf rackid -l 4-6 -i 2 --no-restart
+```
+
+### Start `aerospike`
+
+```bash
+aerolab aerospike start
+```
+
+### Confirm the cluster is working
+
+```bash
+aerolab attach asadm -- -e info
+```

--- a/docs/usage/basic/strong.md
+++ b/docs/usage/basic/strong.md
@@ -1,0 +1,21 @@
+[Docs home](../../../README.md)
+
+# Strong consistency
+
+
+## Create an Aerospike cluster with strong consistency
+
+### Create a cluster, with a custom config and features file
+In this example a three node Aerospike Database cluster is created using a
+Strong Consistency [template](https://github.com/aerospike/aerolab/blob/master/templates/strong-consistency.conf),
+as well as passing in a feature key file to the cluster nodes.
+
+```bash
+$ ./aerolab cluster create -c 3 -o templates/strong-consistency.conf -f features.conf
+```
+
+### Apply the roster
+
+```bash
+$ ./aerolab roster apply -m bar
+```

--- a/docs/usage/basic/tls.md
+++ b/docs/usage/basic/tls.md
@@ -1,0 +1,77 @@
+[Docs home](../../../README.md)
+
+# TLS setup
+
+
+AeroLab can assist you in [configuring TLS](/server/operations/configure/network/tls)
+between client and server, as well as between server nodes.
+
+### Create a two node cluster with a TLS configuration skeleton in place
+
+Note: you can download the template configuration file from this repository, in the templates directory.
+
+```bash
+aerolab cluster create -o templates/tls.conf -c 2 -n mytest
+```
+
+### Generate TLS certificates
+
+```bash
+aerolab tls generate -n mytest
+```
+
+### Restart Aerospike
+
+```bash
+aerolab aerospike restart -n mytest
+```
+
+### Connect using AQL
+
+```bash
+aerolab attach shell -n mytest
+
+# mutual auth off
+aql --tls-enable --tls-cafile=/etc/aerospike/ssl/tls1/cacert.pem -h 127.0.0.1:tls1:4333
+
+# mutual auth on
+aql --tls-enable --tls-cafile=/etc/aerospike/ssl/tls1/cacert.pem --tls-keyfile=/etc/aerospike/ssl/tls1/key.pem --tls-certfile=/etc/aerospike/ssl/tls1/cert.pem -h 127.0.0.1:tls1:4333
+```
+
+### Notes on multiple certificates
+
+`tls generate` will put certificates in the following path in the containers:
+
+```
+/etc/aerospike/{TLS_NAME}/cert.pem
+/etc/aerospike/{TLS_NAME}/cacert.pem
+/etc/aerospike/{TLS_NAME}/key.pem
+```
+
+As such, you can create and use multiple TLS names in your Aerospike config. For example:
+
+```
+network {
+    tls tls1 {
+    cert-file /etc/aerospike/ssl/tls1/cert.pem
+    key-file /etc/aerospike/ssl/tls1/key.pem
+    ca-file /etc/aerospike/ssl/tls1/cacert.pem
+    }
+    tls bob.domain.why.not {
+    cert-file /etc/aerospike/ssl/bob.domain.why.not/cert.pem
+    key-file /etc/aerospike/ssl/bob.domain.why.not/key.pem
+    ca-file /etc/aerospike/ssl/bob.domain.why.not/cacert.pem
+    }
+```
+
+If you use that in your template configuration file, snipped to make-cluster with the -o parameter, simply generate separate certificates for those 2 TLS names as follows:
+```bash
+aerolab tls generate -t tls1
+aerolab tls generate -t bob.domain.why.not
+```
+
+### Other features
+
+TLS generation allows for multiple CA certificates. If a CA cert already exists with the given name, it will be reused. If it doesn't, a new CA with that name will be generated.
+
+AeroLab also has `tls copy` as a handy way to copy TLS certificates from one node to another (or one cluster to another).

--- a/docs/usage/basic/updown.md
+++ b/docs/usage/basic/updown.md
@@ -1,0 +1,18 @@
+[Docs home](../../../README.md)
+
+# Upload and download files
+
+
+## Upload and download files between host and containers
+
+### Upload a file to Aerospike cluster nodes 1 and 2
+
+```bash
+aerolab files upload -n dc1 -l 1,2 file-to-upload.conf /destination/on/nodes/filename.conf
+```
+
+### Download a file from cluster node 1
+
+```bash
+aerolab files download -n dc1 -l 1 /source/on/node/filename.conf filename-to-download-to.conf
+```

--- a/docs/usage/basic/xdr.md
+++ b/docs/usage/basic/xdr.md
@@ -1,0 +1,37 @@
+[Docs home](../../../README.md)
+
+# Cross-datacenter replication
+
+
+## Set up cross-datacenter replication between clusters
+AeroLab makes it easy to deploy distinct clusters that are connected through
+cross-datacenter replication ([XDR](/server/operations/configure/cross-datacenter)).
+
+### Create two Aerospike clusters with XDR between them
+
+Switch | Meaning
+--- | ---
+s | Source cluster name
+c | Number of source nodes
+x | Destination cluster name
+a | Number of destination nodes
+m | List of namespaces to connect
+v | Server version to deploy (default: latest)
+
+```bash
+aerolab xdr create-clusters -n dc1 -c 3 -N dc2 -C 3 -M test,bar -v 5.7.0.12
+```
+
+### Destroy both clusters
+
+```bash
+aerolab cluster destroy -n dc1,dc2 -f
+```
+
+### Create Aerospike clusters manually and join them with XDR
+
+```bash
+aerolab cluster create -n dc1 -c 3 -v 4.9.0.32
+aerolab cluster create -n dc2 -c 3 -v 4.9.0.32
+aerolab xdr connect -s dc1 -d dc2 -M test,bar
+```

--- a/docs/usage/full-stack/full-stack-aws.md
+++ b/docs/usage/full-stack/full-stack-aws.md
@@ -1,0 +1,117 @@
+[Docs home](../../../README.md)
+
+# Full server-client stack with AMS monitoring example for AWS
+
+
+### Define variables
+
+```
+cluster_name="my-cluster"
+client_name="my-client"
+ams_name="ams"
+namespace="test"
+backend="aws"
+aws_region="ca-central-1"
+aws_az="ca-central-1a"
+aws_instance_type_server="t3a.medium"
+aws_instance_type_ams="t3a.large"
+aws_instance_type_client="t3a.medium"
+```
+
+The above variables are examples. Adjust them as necessary for your AWS configuration.
+
+### Configure backend
+
+```
+aerolab config backend -t ${backend} -r ${aws_region}
+```
+
+### Deploy a 5-node cluster
+
+```
+aerolab cluster create -c 5 -n ${cluster_name} -I ${aws_instance_type_server} -U ${aws_az}
+```
+
+### Add exporter to the cluster to monitor in AMS
+
+```
+aerolab cluster add exporter -n ${cluster_name}
+```
+
+## Deploy AMS monitoring stack
+
+### Using AWS or Docker where the containers are directly accessible from the host
+
+```
+aerolab client create ams -n ${ams_name} -s ${cluster_name} -I ${aws_instance_type_ams} -U ${aws_az}
+```
+
+### Deploy 5 tools machines for `asbenchmark`
+
+```
+aerolab client create tools -n ${client_name} -c 5 -I ${aws_instance_type_client} -U ${aws_az}
+```
+
+### Add Promtail to clients to push `asbenchmark` logs to AMS stack
+
+```
+aerolab client configure tools -l all -n ${client_name} --ams ${ams_name}
+```
+
+### Get IP address of AMS node to connect to Grafana
+
+```
+aerolab client list
+```
+
+Note down the IP address of the `AMS` machine. Navigate in your browser to this
+address on port 3000, for example `http://1.2.3.4:3000` (or `http://127.0.0.1:3000`
+if deploying AMS with Docker's port forwarding).
+
+### Run `asbench`
+
+```
+aerolab client attach -n ${client_name} -l all --detach -- /bin/bash -c "run_asbench ...asbench-params..."
+```
+
+### Stop `asbench`
+
+```
+aerolab client attach -n ${client_name} -l all -- pkill -9 asbench
+```
+
+### Cleanup
+
+```
+aerolab cluster destroy -f -n ${cluster_name}
+aerolab client destroy -f -n ${client_name}
+aerolab client destroy -f -n ${ams_name}
+```
+
+## Example `asbench` commands
+
+### Get IP address of a cluster node
+
+```
+NODEIP=$(aerolab cluster list -j |grep -A7 ${cluster_name} |grep IpAddress |head -1 |egrep -o '([0-9]{1,3}\.){3}[0-9]{1,3}')
+echo "Seed: ${NODEIP}"
+```
+
+### Insert data, different set per client
+
+```
+aerolab client attach -n ${client_name} -l all --detach -- /bin/bash -c "run_asbench -h ${NODEIP}:3000 -U superman -Pkrypton -n ${namespace} -s \$(hostname) --latency -b testbin -K 0 -k 1000000 -z 16 -t 0 -o I1 -w I --socket-timeout 200 --timeout 1000 -B allowReplica --max-retries 2"
+```
+
+### Stop `asbench`
+
+```
+aerolab client attach -n ${client_name} -l all -- pkill -9 asbench
+```
+
+
+### Run a read-update load, different set per client
+
+```
+aerolab client attach -n ${client_name} -l all --detach -- /bin/bash -c "run_asbench -h ${NODEIP}:3000 -U superman -Pkrypton -n ${namespace} -s \$(hostname) --latency -b testbin -K 0 -k 1000000 -z 16 -t 86400 -g 1000 -o I1 -w RU,80 --socket-timeout 200 --timeout 1000 -B allowReplica --max-retries 2"
+```

--- a/docs/usage/full-stack/full-stack-docker.md
+++ b/docs/usage/full-stack/full-stack-docker.md
@@ -1,0 +1,109 @@
+[Docs home](../../../README.md)
+
+# Full server-client stack with AMS monitoring example for Docker
+
+
+### Define variables
+
+```
+cluster_name="myCluster"
+client_name="myClient"
+ams_name="ams"
+namespace="test"
+```
+
+### Deploy a 5-node cluster
+
+```
+aerolab cluster create -c 5 -n ${cluster_name}
+```
+
+### Add exporter to the cluster to monitor in AMS
+
+```
+aerolab cluster add exporter -n ${cluster_name}
+```
+
+### Deploy AMS monitoring stack
+
+#### Using AWS or Docker where the containers are directly accessible from the host
+
+```
+aerolab client create ams -n ${ams_name} -s ${cluster_name}
+```
+
+#### Using Docker Desktop without tunneling configured
+
+```
+aerolab client create ams -n ${ams_name} -s ${cluster_name} -e 3000:3000
+```
+
+### Deploy 5 tools machines for `asbenchmark`
+
+```
+aerolab client create tools -n ${client_name} -c 5
+```
+
+### Add Promtail to clients to push `asbenchmark` logs to AMS stack
+
+```
+aerolab client configure tools -l all -n ${client_name} --ams ${ams_name}
+```
+
+### Get IP address of AMS node to connect to Grafana
+
+```
+aerolab client list
+```
+
+Note down the IP address of the `AMS` machine. Navigate in your browser to
+`http://IP:3000` (or `http://127.0.0.1:3000` if deploying AMS with Docker's
+port forwarding).
+
+### Run `asbench`
+
+```
+aerolab client attach -n ${client_name} -l all --detach -- /bin/bash -c "run_asbench ...asbench-params..."
+```
+
+### Stop `asbench`
+
+```
+aerolab client attach -n ${client_name} -l all -- pkill -9 asbench
+```
+
+### Cleanup
+
+```
+aerolab cluster destroy -f -n ${cluster_name}
+aerolab client destroy -f -n ${client_name}
+aerolab client destroy -f -n ${ams_name}
+```
+
+## Example `asbench` commands
+
+### Get IP address of a cluster node
+
+```
+NODEIP=$(aerolab cluster list -j |grep -A7 ${cluster_name} |grep IpAddress |head -1 |egrep -o '([0-9]{1,3}\.){3}[0-9]{1,3}')
+echo "Seed: ${NODEIP}"
+```
+
+### Insert data, different set per client
+
+```
+aerolab client attach -n ${client_name} -l all --detach -- /bin/bash -c "run_asbench -h ${NODEIP}:3000 -U superman -Pkrypton -n ${namespace} -s \$(hostname) --latency -b testbin -K 0 -k 1000000 -z 16 -t 0 -o I1 -w I --socket-timeout 200 --timeout 1000 -B allowReplica --max-retries 2"
+```
+
+### Stop `asbench`
+
+```
+aerolab client attach -n ${client_name} -l all -- pkill -9 asbench
+```
+
+
+### Run a read-update load, different set per client
+
+```
+aerolab client attach -n ${client_name} -l all --detach -- /bin/bash -c "run_asbench -h ${NODEIP}:3000 -U superman -Pkrypton -n ${namespace} -s \$(hostname) --latency -b testbin -K 0 -k 1000000 -z 16 -t 86400 -g 1000 -o I1 -w RU,80 --socket-timeout 200 --timeout 1000 -B allowReplica --max-retries 2"
+```

--- a/docs/usage/full-stack/index.md
+++ b/docs/usage/full-stack/index.md
@@ -1,0 +1,9 @@
+[Docs home](../../../README.md)
+
+# Full-Stack AeroLab Commands
+
+## Sub-topics
+
+[Full server-client stack with AMS monitoring example for Docker](full-stack-docker.md)
+
+[Full server-client stack with AMS monitoring example for AWS](full-stack-aws.md)

--- a/docs/usage/help.md
+++ b/docs/usage/help.md
@@ -1,0 +1,86 @@
+[Docs home](../../README.md)
+
+# Help commands
+
+## Command list
+
+### Top-level commands
+
+Get help on top-level commands.
+
+```bash
+% aerolab help
+Usage:
+  aerolab [OPTIONS] <command>
+
+Available commands:
+  config     Show or change aerolab configuration
+  cluster    Create and manage Aerospike clusters and nodes
+  aerospike  Aerospike daemon controls
+  attach     Attach to a node and run a command
+  net        Firewall and latency simulation
+  conf       Manage Aerospike configuration on running nodes
+  tls        Create or copy TLS certificates
+  data       Insert/delete Aerospike data
+  template   Manage or delete template images
+  installer  List or download Aerospike installer versions
+  logs       show or download logs
+  files      Upload/Download files to/from clients or clusters
+  xdr        Manage clusters' xdr configuration
+  roster     Show or apply strong-consistency rosters
+  version    Print AeroLab version
+  help       Print help
+```
+
+### Sub-commands
+
+Get help on sub-commands of each top-level command.
+
+```bash
+% aerolab cluster help
+Usage:
+  aerolab [OPTIONS] cluster [command]
+
+Available commands:
+  create   Create a new cluster
+  list     List clusters
+  start    Start cluster
+  stop     Stop cluster
+  grow     Add nodes to cluster
+  destroy  Destroy cluster
+  help     Print help
+```
+
+## Command-specific help
+
+Get help on a specific command.
+
+```bash
+% aerolab cluster stop help
+Usage:
+  aerolab [OPTIONS] cluster stop [stop-OPTIONS] [help]
+
+[stop command options]
+      -n, --name=  Cluster names, comma separated OR 'all' to affect all clusters (default: mydc)
+      -l, --nodes= Nodes list, comma separated. Empty=ALL
+
+Available commands:
+  help  Print help
+```
+
+## Command-specific help midway through typing the command
+
+Get help on a specific without executing the command by appending `help` as the last parameter.
+
+```bash
+% aerolab cluster create -n test -c 4 help
+Usage:
+  aerolab [OPTIONS] cluster create [create-OPTIONS] [help]
+
+[create command options]
+      -n, --name=                     Cluster name (default: mydc)
+      -c, --count=                    Number of nodes (default: 1)
+      -o, --customconf=               Custom config file path to install
+      -f, --featurefile=              Features file to install
+...
+```

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -1,0 +1,11 @@
+[Docs home](../../README.md)
+
+# Usage Examples
+
+[Basic](basic/index.md)
+
+[Advanced](advanced/index.md)
+
+[Full-stack](full-stack/index.md)
+
+[Monitoriing](monitoring/index.md)

--- a/docs/usage/monitoring/ams.md
+++ b/docs/usage/monitoring/ams.md
@@ -1,0 +1,74 @@
+[Docs home](../../../README.md)
+
+# Deploy the Aerospike Monitoring Stack
+
+## Deploy the Aerospike Monitoring Stack and Prometheus exporter
+
+The [Aerospike Monitoring Stack](/monitorstack) (AMS)
+provides a monitoring dashboard and alerting through Prometheus, Grafana and the
+Aerospike Prometheus exporter.
+
+### Create a Cluster
+In this example you'll create two Aerospike Database clusters, each with three nodes.
+
+```
+aerolab cluster create -n dc1 -c 3
+aerolab cluster create -n dc2 -c 3
+```
+
+### Install the Prometheus exporter
+
+Add an Aerospike Prometheus exporter agent for each node of both clusters.
+```
+aerolab cluster add exporter -n dc1,dc2
+```
+
+#### Add a custom config for the exporter
+
+You can add a [custom](/monitorstack/configure/configure-exporter) `ape.toml`,
+for example when using authentication or TLS to talk to the Aerospike cluster, like so:
+
+```
+aerolab cluster add exporter -n dc1,dc2 -o /path/to/ape.toml
+```
+
+###### Upgrading the exporter
+
+You can execute the `cluster add exporter` command on the same cluster multiple times.
+This will result in the exporter being upgraded to the latest version with a new `ape.toml` exporter configuration file.
+
+### Add an AMS client
+
+#### Install the AMS client - AWS, Docker on Linux
+
+```
+aerolab client create ams -n ams -s dc1,dc2
+```
+
+#### Install the AMS client - Docker Desktop
+
+```
+aerolab client create ams -n ams -s dc1,dc2 -e 3000:3000
+```
+
+### Update the AMS client's list of node IPs to monitor in a given cluster
+
+You can reconfigure the same AMS client to monitor an updated list of node IPs in a cluster. This command avoids recreating the AMS client machine.
+
+```
+aerolab client configure ams -n ams -s dc1,dc2
+```
+
+### Access the monitoring dashboard
+
+```
+aerolab client list
+```
+
+You can access the AMS client's monitoring dashboard using its IP address and port 3000 in your browser.
+
+For AWS, Docker-Laptop and Docker on Linux, that is: `http://<IP>:3000`
+
+For Docker Desktop, use: `http://127.0.0.1:3000`
+
+The default username and password are: `admin/admin`

--- a/docs/usage/monitoring/index.md
+++ b/docs/usage/monitoring/index.md
@@ -1,0 +1,7 @@
+[Docs home](../../../README.md)
+
+# Monitoring Commands
+
+## Sub-topics
+
+[Deploy the Aerospike Monitoring Stack](ams.md)

--- a/docs/utility_scripts/certs.md
+++ b/docs/utility_scripts/certs.md
@@ -1,0 +1,49 @@
+[Docs home](../../README.md)
+
+# Create new certificates
+
+
+This script is designed to allow you to quickly create a self-signed
+Certificate Authority and generate certificates.
+
+This script automatically generates server, client, admin, ldap, xdr, fabric,
+and heartbeat certificates.
+
+## Clone the repo
+
+```bash
+# Via Web
+git clone https://github.com/aerospike/aerolab.git
+
+# Via SSH
+git clone git@github.com:aerospike/aerolab.git
+```
+
+## Enter the directory
+```bash
+cd aerolab/scripts
+```
+
+## Usage
+
+```bash
+./make-certificates.sh 
+```
+
+Certificates will be placed in ~/rootca
+```
+local/rootCA.pem - Root certificate
+local/rootCA.key - Root certificate key
+
+output/server1.pem - Server certificate
+output/server1.key - Server certificate key
+output/client1.pem - Client certificate
+output/client1.key - Client certificate key
+output/ldap1.pem - LDAP Server certificate
+output/ldap1.key - LDAP Server certificate key
+output/admin1.pem - asadm/aql test certificate
+output/admin1.key - asadm/aql test certificate key
+output/xdr1.pem - XDR certificate
+output/xdr1.key - XDR certificate key
+```
+For reference, the requests used to generate certificates are placed in input.

--- a/docs/utility_scripts/go.md
+++ b/docs/utility_scripts/go.md
@@ -1,0 +1,85 @@
+[Docs home](../../README.md)
+
+# Quick build client - Go
+
+
+This script allows for quick and easy deployment of a Go client library with
+sample code in a Docker container.
+
+This script can be used on its own, as part of an [aerolab-buildenv](/tools/aerolab/utility_scripts/ldap-tls)
+script, or combined with the `aerolab` command.
+
+## Clone the repo
+
+### Using https
+
+```bash
+git clone https://github.com/aerospike/aerolab.git
+```
+
+### Using git keys
+
+```bash
+git clone git@github.com:aerospike/aerolab.git
+```
+
+## Enter the directory
+
+```bash
+cd aerolab/scripts/aerolab-goclient
+```
+
+## Get usage help
+
+```
+./runme.sh
+```
+
+## Create a new Go client container
+
+```bash
+./runme.sh run
+```
+
+### Attach to the client container's shell
+
+```
+./runme.sh attach
+ls
+```
+
+## Destroy the client container
+
+```bash
+./runme.sh destroy
+```
+
+## Usage
+
+```
+./runme.sh 
+
+Usage: ./runme.sh start|stop|destroy|run|get
+
+  run     - create and start Client Node
+  start   - start an existing, stopped, Client Node
+  stop    - stop a running Client Node, without destroying it
+  get     - get the IPs of Client Node
+  attach  - attach to the client container
+  destroy - stop and destroy the Client Node
+```
+
+## Code samples
+
+After you attach to the container, the samples are in the following locations:
+
+* `/root/go/src/v4` for the version 4 library
+* `/root/go/src/v5` for the version 5 library
+
+Each directory contains the following examples:
+
+Name | Description
+--- | ---
+aerospike-basic | Aerospike basic connect, plus some get/put command examples.
+aerospike-auth | Aerospike connect with basic authentication, plus some get/put command examples.
+aerospike-tls | Aerospike connect with TLS and external LDAP authentication, plus some get/put command examples.

--- a/docs/utility_scripts/index.md
+++ b/docs/utility_scripts/index.md
@@ -1,0 +1,15 @@
+[Docs home](../../README.md)
+
+# Utility Scripts
+
+## Sub-topics:
+
+[Create new certificates](certs.md)
+
+[Deploying an LDAP server](ldap.md)
+
+[Build a cluster with LDAP and TLS](ldap-tls.md)
+
+[Quick build client - Python](python.md)
+
+[Quick build client - Go](go.md)

--- a/docs/utility_scripts/ldap-tls.md
+++ b/docs/utility_scripts/ldap-tls.md
@@ -1,0 +1,91 @@
+[Docs home](../../README.md)
+
+# Build a cluster with LDAP and TLS
+
+
+This script is designed to allow you to build a whole environment containing
+an LDAP server with the option of having TLS enabled for both the Aerospike nodes and
+the LDAP server itself, along with a Python and/or Go client host.
+This script depends on the `aerolab-ldap`, `aerolab-goclient` and `aerolab-pythonclient` build
+components to function.
+
+### Clone the repo
+
+#### Using HTTPS
+
+```bash
+git clone https://github.com/aerospike/aerolab.git
+```
+
+#### Using git keys
+
+```bash
+git clone git@github.com:aerospike/aerolab.git
+```
+
+## Enter the directory
+
+```bash
+cd aerolab/scripts/aerolab-buildenv
+```
+
+The config file in this directory allows you to customize your environment.
+Note the following options:
+
+```bash
+#Aerospike Configuration
+TEMPLATE=ldap_tls.conf
+NODES=2
+
+#VERSION should be "-v x.x.x.x"  If it's not set, then Latest will be used
+VERSION=""
+
+#FEATURES should be "-f <pathtofile>"  If it's not set, then ~/aero-lab-common.conf setting will be used
+FEATURES=""
+
+#NETWORKMODE should be "-m <type>"  If it's not set, then ~/aero-lab-common.conf setting will be used
+NETWORKMODE=""
+```
+
+The TEMPLATE is any available standard AeroLab configuration file. The most useful in
+this instance are `ldap.conf` and `ldap_tls.conf`.
+
+With the `VERSION`, `FEATURES` and `NETWORKMODE` items, they also require the appropriate
+command-line switch. For example, `VERSION="-v 5.7.0.13"`.
+
+
+```bash
+# YES/NO
+BUILD_PYTHON="YES"
+BUILD_GO="YES"
+```
+The BUILD options allow you to select which client containers will be built and started.
+
+Once you have set your configurations, you can build the environment. From this point on, the process is automated.
+Any changes that you make to either your LDAP `ldif` files or environment configuration will persist between uses. To restore the standard build, remove your directory and re-clone the repo.
+
+
+---
+## Create new environment
+One of the first things that happens when you deploy your environment is that it will destroy whatever was built last time. If you change your config between building and destroying, it may not destroy your environment correctly.
+
+```bash
+./deploy-env.sh
+```
+
+---
+## Destroy
+This will destroy the previously-built environment:
+
+```bash
+./destroy-env.sh
+```
+
+---
+## Get Help
+When you deploy your environment, it will automatically give you a list of useful commands.
+You can see the list at any time with the following command:
+
+```bash
+./deploy-env.sh help
+```

--- a/docs/utility_scripts/ldap.md
+++ b/docs/utility_scripts/ldap.md
@@ -1,0 +1,82 @@
+[Docs home](../../README.md)
+
+# Deploying an LDAP server
+
+
+This script set allows for easy deployment of an LDAP server with or without TLS,
+and LDAP admin web UI in docker containers.
+
+This script can be used on its own, or as part of an [aerolab-buildenv](/tools/aerolab/utility_scripts/ldap-tls)
+script, or in combination with `aerolab` commands.
+
+## Usage
+
+```
+./runme.sh
+
+Usage: ./runme.sh start|stop|destroy|run|get
+
+  run     - create and start LDAP stack
+  start   - start an existing, stopped, LDAP stack
+  stop    - stop a running LDAP stack, without destroying it
+  get     - get the IPs of LDAP stack
+  help    - get a list of useful commands for cli ldapsearch
+  destroy - stop and destroy the LDAP stack
+```
+
+## Getting started
+
+### Clone the repo
+
+```bash
+git clone https://github.com/aerospike/aerolab.git
+```
+
+### Enter the directory
+
+```bash
+cd aerolab/scripts/aerolab-ldap
+```
+
+### Get usage help
+
+```bash
+./runme.sh
+```
+
+### Run new LDAP server with LDAP admin
+
+```bash
+./runme.sh run
+```
+
+### Destroy
+
+```bash
+./runme.sh destroy
+```
+
+## Notes
+
+  * All certificates are in the `certs/` directory.
+  * This LDAP supports both ldap:// and ldaps:// (SSL) out of the box.
+  * Hostname and CN for the certificate for the ldap server is `ldap1`.
+  * This also deploys the ldapadmin web GUI for web administration (create/delete groups/users).
+  * At the end of `runme.sh run`, a useful list of commands and IPs is printed to access the ldap and web UI.
+  * Run `runme.sh get` to get the useful list again.
+  * When configuring LDAP on the Aerospike side, specify 
+    either `ldap://ldap1:389` or `ldaps://ldap1:636` in the LDAP server name.
+  * You then need to add the `ldap1` host pointing at the IP of the LDAP server in the `/etc/hosts` file.
+    This is because Aerospike will only be able to connect and verify if the hostname of the
+    LDAP server matches the CN of certificate the LDAP server uses, which is `ldap1`.
+  * Take note of `LDAP_TLS_VERIFY_CLIENT: try` in docker-compose.yml. If that is set to `demand`,
+    the LDAP server requires mutual certificate authentication with the Aerospike server. The server will need
+    a proper certificate for that, not just the CA.
+
+## Advanced
+
+### Export/Import
+
+From the ldap-admin UI you can export `ldif` files. You can then import those files by putting
+your definitions in the `ldif/` directory. These will be automatically deployed when you do
+the `run` command again.

--- a/docs/utility_scripts/python.md
+++ b/docs/utility_scripts/python.md
@@ -1,0 +1,82 @@
+[Docs home](../../README.md)
+
+# Quick build client - Python
+
+
+This script allows for quick and easy deployment of a Python-based client
+library with sample code in a Docker container.
+
+It can be used on its own, as part of an [aerolab-buildenv](/tools/aerolab/utility_scripts/ldap-tls)
+script, or combined with the `aerolab` command.
+
+## Clone the repo
+
+### Using https
+
+```bash
+git clone https://github.com/aerospike/aerolab.git
+```
+
+### Using git keys
+
+```bash
+git clone git@github.com:aerospike/aerolab.git
+```
+
+## Enter the directory
+
+```bash
+cd aerolab/scripts/aerolab-pythonclient
+```
+
+## Get usage help
+
+```bash
+./runme.sh
+```
+
+### Create a new Python client container
+
+```bash
+./runme.sh run
+```
+
+### Attach to the client container's shell
+
+```bash
+./runme.sh attach
+ls
+```
+
+## Destroy the client container
+
+```bash
+./runme.sh destroy
+```
+
+## Usage
+
+```bash
+./runme.sh 
+
+Usage: ./runme.sh start|stop|destroy|run|get
+
+  run     - create and start Client Node
+  start   - start an existing, stopped, Client Node
+  stop    - stop a running Client Node, without destroying it
+  get     - get the IPs of Client Node
+  attach  - attach to the client container
+  destroy - stop and destroy the Client Node
+```
+
+## Code samples
+
+Once you have attached to the container, you will see the client example code in `/root/clients`.
+
+There are 3 example code snippets:
+
+Name | Description
+--- | ---
+example_basic.py | Does a basic database connect, writes a record and reads it back.
+example_auth.py | Does an authenticated database connect, writes a record and reads it back.
+example_tls.py | Does an authenticated database connect over TLS, writes a record and reads it back.

--- a/docs/vpc.md
+++ b/docs/vpc.md
@@ -1,0 +1,34 @@
+[Docs home](../README.md)
+
+# Custom VPC setup notes
+
+
+### VPC setup for AWS
+
+Procedure:
+
+1. Create VPC.
+2. Create subnets for the VPC, if not automatically done.
+3. For each subnet, edit subnet settings and ensure "Auto-assign public IPv4" is checked, or a public IP address won't be assigned to the instances.
+
+### Internet gateway
+
+By default a new VPC cannot be routed to the internet. This needs to be configured.
+
+1. Create an Internet Gateway.
+2. Attach the Internet Gateway to the VPC.
+3. Under subnets, select one of the new subnets and check which route table is in use.
+4. Navigate to Route Tables and select the relevant route table.
+5. Ensure that a route exists (or add a route if it does not) as follows:
+   - CIDR: 0.0.0.0/0
+   - Gateway/Router: the Internet Gateway we have created and attached to the VPC.
+
+### Summary
+
+The following elements should be created or checked to ensure proper networking status:
+
+1. VPC
+2. Subnets with auto-assign of public IPv4
+3. Internet Gateway
+4. Internet Gateway attached to VPC
+5. Internet Gateway added to the routing table in use by the VPC/subnets


### PR DESCRIPTION
Expanded README.md with all sections and sub-sections from https://docs.aerospike.com/tools/aerolab.