### PR TITLE
Update cmdTlsGenerate.go

### DIFF
--- a/src/cmdTlsGenerate.go
+++ b/src/cmdTlsGenerate.go
@@ -94,9 +94,9 @@ func (c *tlsGenerateCmd) Execute(args []string) error {
 	_, errA := os.Stat("CA/private/" + c.CaName + ".key")
 	_, errB := os.Stat("CA/" + c.CaName + ".pem")
 	if errA != nil || errB != nil {
-		commands = append(commands, []string{"req", "-new", "-nodes", "-x509", "-extensions", "v3_ca", "-keyout", "private/" + c.CaName + ".key", "-out", c.CaName + ".pem", "-days", "3650", "-config", "./openssl.cnf", "-subj", fmt.Sprintf("/C=US/ST=Denial/L=Springfield/O=Dis/CN=%s", c.CaName)})
+		commands = append(commands, []string{"req", "-new", "-nodes", "-x509", "-extensions", "v3_ca", "-keyout", "private/" + c.CaName + ".key", "-out", c.CaName + ".pem", "-days", "3650", "-config", "./openssl.cnf", "-subj", fmt.Sprintf("/C=US/ST=CA/L=Cyberspace/O=Aerolab/CN=%s", c.CaName)})
 	}
-	commands = append(commands, []string{"req", "-new", "-nodes", "-extensions", "v3_req", "-out", "req.pem", "-config", "./openssl.cnf", "-subj", fmt.Sprintf("/C=US/ST=Denial/L=Springfield/O=Dis/CN=%s", c.TlsName)})
+	commands = append(commands, []string{"req", "-new", "-nodes", "-extensions", "v3_req", "-out", "req.pem", "-config", "./openssl.cnf", "-subj", fmt.Sprintf("/C=US/ST=CA/L=Cyberspace/O=Aerolab/CN=%s", c.TlsName)})
 	commands = append(commands, []string{"ca", "-batch", "-extensions", "v3_req", "-out", "cert.pem", "-config", "./openssl.cnf", "-infiles", "req.pem"})
 	//os.RemoveAll("CA")
 	if _, err := os.Stat("CA"); err != nil {


### PR DESCRIPTION
Change the subject and the issuer away from a real domain, and this only came up during a recent troubleshooting an live issue, ds.denial.us turned out to be a real domain name, so this briefly distracted the team doing the troubleshooting.