### PR TITLE
Adds additional export options

### DIFF
--- a/docs/usage/advanced/export-inventory.md
+++ b/docs/usage/advanced/export-inventory.md
@@ -1,0 +1,195 @@
+# Exporting Aerolab Inventory
+
+## Why?
+
+The primary purpose for exporting the inventory is to allow for a natural way to extend or customize
+your `aerolab` deployed clusters. `aerolab` knows what has been deployed, and the relevant details. 
+By exporting inventories that other tools know about, those tools can pick up where `aerolab` finishes,
+and this should provide a natural escape hatch.
+
+For teams that share a cloud account, be advised that setting the `PROJECT_NAME` env variable limits the output to 
+those instances that have been tagged with `project=<PROJECT_NAME>` either at creation time like this:
+```shell
+ aerolab cluster create ... \
+          --tags=project=${PROJECT_NAME} \   # when using the AWS backend
+          --label=project=${PROJECT_NAME} \  # When using the GCP backend
+          ...
+EOF
+```
+Note that you can pass both parameters, `aerolab` will silently ignore those that don't apply to the currently
+configured backend. This allows the user to create scripts that work as the user switches backends. It is possible to 
+manually via the cloud's console or CLI commands.
+
+For example, like this in GCP:
+```shell
+gcloud compute instances add-labels "aerolab4-${CLUSTER_NAME}-${NODE_NO}" --labels=project=${PROJECT_NAME}
+```
+
+or like this in AWS:
+
+```shell
+aws ec2 create-tags \
+    --resources ami-1234567890abcdef0 \
+    --tags Key=project,Value=${PROJECT_NAME}
+```
+
+## Supported Formats
+
+### Hostfile
+
+These lines are to be used to update your `/etc/hosts` file. Doing so will allow you to move around the cluster more
+easily, using the hostname or the node's name as it appears in your clouds console. Additionally, if you leverage this
+pattern of configuring your systems, you can side step the need to hard-code IPs in in configuration files, because
+after deploy, updating `/etc/hosts` will allow for the systems to leverage the OS's hostname resolution to find the right 
+machine.
+
+```shell
+$ aerolab inventory hostfile
+10.128.0.3    aerolab4-aerospike-1            aerospike-1
+10.128.0.4    aerolab4-aerospike-2            aerospike-2
+10.128.0.10   aerolab4-ghost-rider-cluster-1  ghost-rider-cluster-1
+10.128.0.24   aerolab4-ghost-rider-cluster-2  ghost-rider-cluster-2
+10.128.0.25   aerolab4-ghost-rider-cluster-3  ghost-rider-cluster-3
+10.128.0.26   aerolab4-ghost-rider-cluster-4  ghost-rider-cluster-4
+10.128.0.28   aerolab4-ghost-rider-cluster-5  ghost-rider-cluster-5
+10.128.0.34   aerolab4-aerospike-client-1     aerospike-client-1
+10.128.0.82   aerolab4-ann-client-1           ann-client-1
+10.128.0.22   aerolab4-ghost-rider-1          ghost-rider-1
+10.128.0.19   aerolab4-darkhold-1             darkhold-1
+10.128.0.29   aerolab4-maphisto-1             maphisto-1
+```
+
+And you can filter,
+
+```shell
+$ PROJECT_NAME=maphisto aerolab inventory hostfile
+10.128.0.3              aerolab4-aerospike-1         aerospike-1
+10.128.0.4              aerolab4-aerospike-2         aerospike-2
+10.128.0.34             aerolab4-aerospike-client-1  aerospike-client-1
+10.128.0.19             aerolab4-darkhold-1          darkhold-1
+10.128.0.29             aerolab4-maphisto-1          maphisto-1
+```
+
+### Ansible Inventory
+
+Ansible allows for executables to provide dynamic inventories, and `aerolab` is leveraging the "inventory scripts" method
+ [[docs](https://docs.ansible.com/ansible/latest/dev_guide/developing_inventory.html#developing-inventory-scripts)].
+
+`Ansible` expects to be able to call an executable directly, without subcommands. `aerolab` supports the same calling convention
+that busybox does, where it changes its behavior based on what the shell invokes the binary as. Just like busy box, a single 
+binary can be symlinked to masquerade as many separate utilities. To set this up, run `aerolab` like so:
+
+```shell
+[root@aerolab4-maphisto-1 maphisto]# aerolab showcommands
+2024/08/01 17:39:20 +0000 Discovered absolute path: /usr/bin/aerolab
+2024/08/01 17:39:20 +0000 > ln -s /usr/bin/aerolab /usr/local/bin/showconf
+2024/08/01 17:39:20 +0000 > ln -s /usr/bin/aerolab /usr/local/bin/showsysinfo
+2024/08/01 17:39:20 +0000 > ln -s /usr/bin/aerolab /usr/local/bin/showinterrupts
+2024/08/01 17:39:20 +0000 > ln -s /usr/bin/aerolab /usr/local/bin/aerolab-ansible
+2024/08/01 17:39:20 +0000 Done
+```
+
+This then enables the following behaviour
+
+```shell
+[root@aerolab4-maphisto-1 maphisto]# aerolab-ansible
+{
+  "_meta": {
+    "hostvars": {
+      ...
+      "10.128.0.21": {
+        "aerolab_cluster": "aerospike-client",
+        "ansible_host": "10.128.0.21",
+        "ansible_ssh_private_key_file": "/root/aerolab-keys/aerolab-gcp-aerospike-client",
+        "ansible_user": "root",
+        "instance_id": "aerolab4-aerospike-client-1",
+        "node_name": "aerospike-client-1",
+        "project": "maphisto"
+      },
+      "10.128.0.27": {
+        "aerolab_cluster": "aerospike",
+        "ansible_host": "10.128.0.27",
+        "ansible_ssh_private_key_file": "/root/aerolab-keys/aerolab-gcp-aerospike",
+        "ansible_user": "root",
+        "instance_id": "aerolab4-aerospike-3",
+        "node_name": "aerospike-3",
+        "project": "maphisto"
+      },
+      ...
+    }
+  },
+  "aerospike": {
+    "hosts": [
+      "10.128.0.3",
+      ...
+    ]
+  },
+  "avs": {
+    "hosts": [
+      "10.128.0.19",
+      ...
+    ]
+  },
+  "jumpbox": {
+    "hosts": [
+      "10.128.0.29"
+    ]
+  },
+  "tools": {
+    "hosts": [
+      "10.128.0.21",
+      ...
+    ]
+  }
+}
+```
+
+And finally, you can tie it all together like this
+
+```shell
+ANSIBLE_STDOUT_CALLBACK=unixy ansible-playbook -f 64 -i /usr/local/bin/aerolab-ansible "${CURRENT_PROJECT_ROOT}"/project-ansible/project_environment.yaml
+```
+
+### Genders File
+
+The High Performance Computing Systems Group, at the Lawrence Livermore National Laboratory, 
+has a suite of tools that they use to address configuration management issues that arise on clusters.
+
++ [`genders`](https://github.com/chaos/genders/blob/master/TUTORIAL)
++ [`nodeattr`](https://linux.die.net/man/1/nodeattr)
++ [`pdsh`](https://github.com/chaos/pdsh)
++ [`pdcp`](https://linux.die.net/man/1/pdcp)
++ [`rpdcp`](https://linux.die.net/man/1/pdcp)
+
+the `aerolab inventory genders` command generated a file that is conventionally placed at `/etc/genders`, and looks like
+
+```shell
+$ aerolab inventory genders
+aerospike-1             aerospike,group=aerospike,project=maphisto,all,pdsh_rcmd_type=ssh
+aerospike-2             aerospike,group=aerospike,project=maphisto,all,pdsh_rcmd_type=ssh
+ghost-rider-cluster-1   ghost-rider-cluster,group=aerospike,project=ghost-rider,all,pdsh_rcmd_type=ssh
+ghost-rider-cluster-2   ghost-rider-cluster,group=aerospike,project=ghost-rider,all,pdsh_rcmd_type=ssh
+ghost-rider-cluster-3   ghost-rider-cluster,group=aerospike,project=ghost-rider,all,pdsh_rcmd_type=ssh
+ghost-rider-cluster-4   ghost-rider-cluster,group=aerospike,project=ghost-rider,all,pdsh_rcmd_type=ssh
+ghost-rider-cluster-5   ghost-rider-cluster,group=aerospike,project=ghost-rider,all,pdsh_rcmd_type=ssh
+aerospike-client-1      aerospike-client,group=tools,project=maphisto,all,pdsh_rcmd_type=ssh
+ann-client-1            ann-client,group=jumpbox,project=ann-client,all,pdsh_rcmd_type=ssh
+ghost-rider-1           ghost-rider,group=jumpbox,project=ghost-rider,all,pdsh_rcmd_type=ssh
+darkhold-1              darkhold,group=avs,project=maphisto,all,pdsh_rcmd_type=ssh
+maphisto-1              maphisto,group=jumpbox,project=maphisto,all,pdsh_rcmd_type=ssh
+```
+
+and to filter down to a specific project
+
+```shell
+$ PROJECT_NAME=maphisto aerolab inventory genders
+aerospike-1             aerospike,group=aerospike,project=maphisto,all,pdsh_rcmd_type=ssh
+aerospike-2             aerospike,group=aerospike,project=maphisto,all,pdsh_rcmd_type=ssh
+aerospike-client-1      aerospike-client,group=tools,project=maphisto,all,pdsh_rcmd_type=ssh
+darkhold-1              darkhold,group=avs,project=maphisto,all,pdsh_rcmd_type=ssh
+maphisto-1              maphisto,group=jumpbox,project=maphisto,all,pdsh_rcmd_type=ssh
+```
+
+Perhaps the biggest reason to leverage tools like `pdsh` or `rpdcp` over `aerolab cluster attach` or `aerolab files` is that 
+the `/etc/genders` and `/etc/hosts` files serve as a cache of the deployed systems, which makes the LLNL tools feel magically 
+fast.

--- a/docs/usage/advanced/index.md
+++ b/docs/usage/advanced/index.md
@@ -9,3 +9,5 @@
 [Encryption at rest](encryption.md)
 
 [Custom Aerospike build](custom-build.md)
+
+[Exporting Inventory](export-inventory.md)

--- a/src/cmdInventory.go
+++ b/src/cmdInventory.go
@@ -7,6 +7,8 @@ import (
 type inventoryCmd struct {
 	List          inventoryListCmd          `command:"list" subcommands-optional:"true" description:"List clusters, clients and templates" webicon:"fas fa-list"`
 	Ansible       inventoryAnsibleCmd       `command:"ansible" subcommands-optional:"true" description:"Export inventory as ansible inventory" webicon:"fas fa-list"`
+	Genders       inventoryGendersCmd       `command:"genders" subcommands-optional:"true" description:"Export inventory as genders file" webicon:"fas fa-list"`
+	Hostfile      inventoryHostfileCmd      `command:"hostfile" subcommands-optional:"true" description:"Export inventory as hosts file" webicon:"fas fa-list"`
 	InstanceTypes inventoryInstanceTypesCmd `command:"instance-types" subcommands-optional:"true" description:"Lookup GCP|AWS available instance types" webicon:"fas fa-table-list"`
 	Help          helpCmd                   `command:"help" subcommands-optional:"true" description:"Print help"`
 }

--- a/src/cmdInventoryGenders.go
+++ b/src/cmdInventoryGenders.go
@@ -35,7 +35,7 @@ func (c *inventoryGendersCmd) run() error {
 		project string,
 	) {
 		nodeName := fmt.Sprintf("%s-%s", clusterName, nodeNo)
-		entry := fmt.Sprintf("%s\t\t%s,group=%s,project=%s,all,pdsh_rcmd_type=ssh", nodeName, clusterName, groupName, project)
+		entry := fmt.Sprintf("%s\t%s,group=%s,project=%s,all,pdsh_rcmd_type=ssh", nodeName, clusterName, groupName, project)
 		processedInventory = append(processedInventory, entry)
 	}
 

--- a/src/cmdInventoryGenders.go
+++ b/src/cmdInventoryGenders.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+type inventoryGendersCmd struct{}
+
+func (c *inventoryGendersCmd) Execute(args []string) error {
+	if earlyProcess(args) {
+		return nil
+	}
+	return c.run()
+}
+
+func (c *inventoryGendersCmd) run() error {
+	projectName := os.Getenv("PROJECT_NAME")
+
+	inventoryItems := []int{}
+	inventoryItems = append(inventoryItems, InventoryItemClusters)
+	inventoryItems = append(inventoryItems, InventoryItemClients)
+
+	inventory, err := b.Inventory("", inventoryItems)
+	if err != nil {
+		return fmt.Errorf("b.Inventory: %s", err)
+	}
+
+	var processedInventory []string
+
+	processCluster := func(
+		clusterName string,
+		nodeNo string,
+		groupName string,
+		project string,
+	) {
+		nodeName := fmt.Sprintf("%s-%s", clusterName, nodeNo)
+		entry := fmt.Sprintf("%s\t\t%s,group=%s,project=%s,all,pdsh_rcmd_type=ssh", nodeName, clusterName, groupName, project)
+		processedInventory = append(processedInventory, entry)
+	}
+
+	for _, cluster := range inventory.Clusters {
+		project := searchField("project", cluster.AwsTags, cluster.GcpLabels, cluster.DockerLabels)
+
+		if projectName != "" {
+			if project != projectName {
+				continue
+			}
+		}
+
+		groupName := "aerospike"
+		if cluster.Features&ClusterFeatureAGI > 0 {
+			groupName = "agi"
+		}
+
+		processCluster(
+			cluster.ClusterName,
+			cluster.NodeNo,
+			groupName,
+			project,
+		)
+	}
+
+	for _, cluster := range inventory.Clients {
+		project := searchField("project", cluster.AwsTags, cluster.GcpLabels, cluster.DockerLabels)
+
+		if projectName != "" {
+			if project != projectName {
+				continue
+			}
+		}
+		processCluster(
+			cluster.ClientName,
+			cluster.NodeNo,
+			cluster.ClientType,
+			project,
+		)
+	}
+
+	for _, entry := range processedInventory {
+		fmt.Println(entry)
+	}
+
+	return nil
+}

--- a/src/cmdInventoryHostfile.go
+++ b/src/cmdInventoryHostfile.go
@@ -35,7 +35,7 @@ func (c *inventoryHostfileCmd) run() error {
 		nodeNo string,
 	) {
 		nodeName := fmt.Sprintf("%s-%s", clusterName, nodeNo)
-		entry := fmt.Sprintf("%s\t\t%s\t\t%s", privateIP, instanceId, nodeName)
+		entry := fmt.Sprintf("%s\t%s\t%s", privateIP, instanceId, nodeName)
 		processedInventory = append(processedInventory, entry)
 	}
 

--- a/src/cmdInventoryHostfile.go
+++ b/src/cmdInventoryHostfile.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+type inventoryHostfileCmd struct{}
+
+func (c *inventoryHostfileCmd) Execute(args []string) error {
+	if earlyProcess(args) {
+		return nil
+	}
+	return c.run()
+}
+
+func (c *inventoryHostfileCmd) run() error {
+	projectName := os.Getenv("PROJECT_NAME")
+
+	inventoryItems := []int{}
+	inventoryItems = append(inventoryItems, InventoryItemClusters)
+	inventoryItems = append(inventoryItems, InventoryItemClients)
+
+	inventory, err := b.Inventory("", inventoryItems)
+	if err != nil {
+		return fmt.Errorf("b.Inventory: %s", err)
+	}
+
+	var processedInventory []string
+
+	processCluster := func(
+		privateIP string,
+		instanceId string,
+		clusterName string,
+		nodeNo string,
+	) {
+		nodeName := fmt.Sprintf("%s-%s", clusterName, nodeNo)
+		entry := fmt.Sprintf("%s\t\t%s\t\t%s", privateIP, instanceId, nodeName)
+		processedInventory = append(processedInventory, entry)
+	}
+
+	for _, cluster := range inventory.Clusters {
+		project := searchField("project", cluster.AwsTags, cluster.GcpLabels, cluster.DockerLabels)
+
+		if projectName != "" {
+			if project != projectName {
+				continue
+			}
+		}
+
+		processCluster(
+			cluster.PrivateIp,
+			cluster.InstanceId,
+			cluster.ClusterName,
+			cluster.NodeNo,
+		)
+	}
+
+	for _, cluster := range inventory.Clients {
+		project := searchField("project", cluster.AwsTags, cluster.GcpLabels, cluster.DockerLabels)
+
+		if projectName != "" {
+			if project != projectName {
+				continue
+			}
+		}
+		processCluster(
+			cluster.PrivateIp,
+			cluster.InstanceId,
+			cluster.ClientName,
+			cluster.NodeNo,
+		)
+	}
+
+	for _, entry := range processedInventory {
+		fmt.Println(entry)
+	}
+
+	return nil
+}


### PR DESCRIPTION
+ genders format
+ hostfile format

Example usage:

```shell
$ PROJECT_NAME=proximus-ann go run . inventory genders
aerospike-1             aerospike,group=aerospike,project=proximus-ann,all,pdsh_rcmd_type=ssh
aerospike-2             aerospike,group=aerospike,project=proximus-ann,all,pdsh_rcmd_type=ssh
aerospike-client-1              aerospike-client,group=tools,project=proximus-ann,all,pdsh_rcmd_type=ssh
proximus-1              proximus,group=avs,project=proximus-ann,all,pdsh_rcmd_type=ssh
proximus-ann-1          proximus-ann,group=jumpbox,project=proximus-ann,all,pdsh_rcmd_type=ssh
$ PROJECT_NAME=proximus-ann go run . inventory hostfile
10.128.0.3              aerolab4-aerospike-1            aerospike-1
10.128.0.4              aerolab4-aerospike-2            aerospike-2
10.128.0.34             aerolab4-aerospike-client-1             aerospike-client-1
10.128.0.19             aerolab4-proximus-1             proximus-1
10.128.0.29             aerolab4-proximus-ann-1         proximus-ann-1
$ go run . inventory genders
aerospike-1             aerospike,group=aerospike,project=proximus-ann,all,pdsh_rcmd_type=ssh
aerospike-2             aerospike,group=aerospike,project=proximus-ann,all,pdsh_rcmd_type=ssh
phil-graph-cluster-1            phil-graph-cluster,group=aerospike,project=phil-graph,all,pdsh_rcmd_type=ssh
phil-graph-cluster-2            phil-graph-cluster,group=aerospike,project=phil-graph,all,pdsh_rcmd_type=ssh
phil-graph-cluster-3            phil-graph-cluster,group=aerospike,project=phil-graph,all,pdsh_rcmd_type=ssh
phil-graph-cluster-4            phil-graph-cluster,group=aerospike,project=phil-graph,all,pdsh_rcmd_type=ssh
phil-graph-cluster-5            phil-graph-cluster,group=aerospike,project=phil-graph,all,pdsh_rcmd_type=ssh
aerospike-client-1              aerospike-client,group=tools,project=proximus-ann,all,pdsh_rcmd_type=ssh
ann-client-1            ann-client,group=jumpbox,project=ann-client,all,pdsh_rcmd_type=ssh
phil-graph-1            phil-graph,group=jumpbox,project=phil-graph,all,pdsh_rcmd_type=ssh
proximus-1              proximus,group=avs,project=proximus-ann,all,pdsh_rcmd_type=ssh
proximus-ann-1          proximus-ann,group=jumpbox,project=proximus-ann,all,pdsh_rcmd_type=ssh
$ go run . inventory hostfile
10.128.0.3              aerolab4-aerospike-1            aerospike-1
10.128.0.4              aerolab4-aerospike-2            aerospike-2
10.128.0.10             aerolab4-phil-graph-cluster-1           phil-graph-cluster-1
10.128.0.24             aerolab4-phil-graph-cluster-2           phil-graph-cluster-2
10.128.0.25             aerolab4-phil-graph-cluster-3           phil-graph-cluster-3
10.128.0.26             aerolab4-phil-graph-cluster-4           phil-graph-cluster-4
10.128.0.28             aerolab4-phil-graph-cluster-5           phil-graph-cluster-5
10.128.0.34             aerolab4-aerospike-client-1             aerospike-client-1
10.128.0.82             aerolab4-ann-client-1           ann-client-1
10.128.0.22             aerolab4-phil-graph-1           phil-graph-1
10.128.0.19             aerolab4-proximus-1             proximus-1
10.128.0.29             aerolab4-proximus-ann-1         proximus-ann-1
```

TODO:
+ [ ] Docs
+ [ ] enhance help text
+ [ ] refactor CLI - consider `aerolab inventory export --format [ansible|genders|hostfile]` style
+ [ ] validate refactor doesn't break the "busybox" trick that enables the ansible inventory trick to work
+ [ ] Should the ansible inventory "busybox" link take the `--list` option?