### PR TITLE
Use PARTUUID for cluster partition commands

### DIFF
--- a/src/cmdClusterPartition.go
+++ b/src/cmdClusterPartition.go
@@ -42,17 +42,18 @@ type blockDeviceInformation struct {
 }
 
 type blockDevices struct {
-	Name       string         `json:"name"`
-	Path       string         `json:"path"`
-	FsType     string         `json:"fstype"`
-	FsSize     string         `json:"fssize"`
-	MountPoint string         `json:"mountpoint"`
-	Model      string         `json:"model"` // "Amazon EC2 NVMe Instance Storage" or "Amazon Elastic Block Store"
-	Size       string         `json:"size"`
-	Type       string         `json:"type"` // loop or disk or part
-	PartUUID   string         `json:"partuuid"`
-	Children   []blockDevices `json:"children"`
-	diskNo     int
-	partNo     int
-	nodeNo     int
+	Name         string         `json:"name"`
+	Path         string         `json:"path"`
+	FsType       string         `json:"fstype"`
+	FsSize       string         `json:"fssize"`
+	MountPoint   string         `json:"mountpoint"`
+	Model        string         `json:"model"` // "Amazon EC2 NVMe Instance Storage" or "Amazon Elastic Block Store"
+	Size         string         `json:"size"`
+	Type         string         `json:"type"` // loop or disk or part
+	PartUUID     string         `json:"partuuid"`
+	PartUUIDPath string         `json:"partuuid_path"`
+	Children     []blockDevices `json:"children"`
+	diskNo       int
+	partNo       int
+	nodeNo       int
 }

--- a/src/cmdClusterPartition.go
+++ b/src/cmdClusterPartition.go
@@ -50,6 +50,7 @@ type blockDevices struct {
 	Model      string         `json:"model"` // "Amazon EC2 NVMe Instance Storage" or "Amazon Elastic Block Store"
 	Size       string         `json:"size"`
 	Type       string         `json:"type"` // loop or disk or part
+	PartUUID   string         `json:"partuuid"`
 	Children   []blockDevices `json:"children"`
 	diskNo     int
 	partNo     int

--- a/src/cmdClusterPartitionConf.go
+++ b/src/cmdClusterPartitionConf.go
@@ -113,7 +113,7 @@ func (c *clusterPartitionConfCmd) doParallel(nodeNo int, disks map[int]map[int]b
 }
 
 func (c *clusterPartitionConfCmd) do(nodeNo int, disks map[int]map[int]blockDevices, filterDiskCount int, filterPartCount int) error {
-	is7 := "mounts-budget"
+	isv7 := true
 	outn, err := b.RunCommands(c.ClusterName.String(), [][]string{{"cat", "/opt/aerolab.aerospike.version"}}, []int{nodeNo})
 	if err != nil {
 		log.Printf("could not read /opt/aerolab.aerospike.version on node %d, assuming asd version 7: %s", nodeNo, err)
@@ -124,84 +124,70 @@ func (c *clusterPartitionConfCmd) do(nodeNo int, disks map[int]map[int]blockDevi
 			log.Printf("could not parse /opt/aerolab.aerospike.version on node %d, assuming asd version 7: %s", nodeNo, err)
 		} else {
 			if majorInt < 7 {
-				is7 = "mounts-size-limit"
+				isv7 = false
 			}
 		}
 	}
+
 	outn, err = b.RunCommands(c.ClusterName.String(), [][]string{{"cat", "/etc/aerospike/aerospike.conf"}}, []int{nodeNo})
 	if err != nil {
 		return fmt.Errorf("could not read aerospike.conf on node %d: %s", nodeNo, err)
 	}
 	aconf := outn[0]
-	cc, err := aeroconf.Parse(bytes.NewReader(aconf))
+	conf, err := aeroconf.Parse(bytes.NewReader(aconf))
 	if err != nil {
 		return fmt.Errorf("could not parse aerospike.conf on node %d: %s", nodeNo, err)
 	}
-	if cc.Type("namespace "+c.Namespace) == aeroconf.ValueNil {
-		cc.NewStanza("namespace " + c.Namespace)
+
+	if conf.Type("namespace "+c.Namespace) == aeroconf.ValueNil {
+		err := conf.NewStanza("namespace " + c.Namespace)
+		if err != nil {
+			return logFatal("could not create namespace stanza %s: %v", c.Namespace, err)
+		}
 	}
+
+	//  Create a namespace if it does not exist
+	namespace := conf.Stanza("namespace " + c.Namespace)
+	if namespace == nil {
+		return logFatal("namespace " + c.Namespace + " does not exist")
+	}
+
+	// Clear devices and validate the existing configuration in the namespace
 	switch c.ConfDest {
 	case "memory":
-		for _, key := range cc.Stanza("namespace " + c.Namespace).ListKeys() {
-			if strings.HasPrefix(key, "storage-engine") && (!strings.HasSuffix(key, "memory") || cc.Stanza("namespace "+c.Namespace).Type("storage-engine memory") != aeroconf.ValueStanza) {
-				cc.Stanza("namespace " + c.Namespace).Delete(key)
-			}
+		err := prepareNamespaceForMemoryStorage(&namespace)
+		if err != nil {
+			return err
 		}
-		if cc.Stanza("namespace "+c.Namespace).Type("storage-engine memory") == aeroconf.ValueNil {
-			cc.Stanza("namespace " + c.Namespace).NewStanza("storage-engine memory")
-		}
-		cc.Stanza("namespace " + c.Namespace).Stanza("storage-engine memory").Delete("device")
-		cc.Stanza("namespace " + c.Namespace).Stanza("storage-engine memory").Delete("file")
-		cc.Stanza("namespace " + c.Namespace).Stanza("storage-engine memory").Delete("filesize")
-		cc.Stanza("namespace " + c.Namespace).Stanza("storage-engine memory").Delete("data-size")
 	case "device":
-		for _, key := range cc.Stanza("namespace " + c.Namespace).ListKeys() {
-			if strings.HasPrefix(key, "storage-engine") && (!strings.HasSuffix(key, "device") || cc.Stanza("namespace "+c.Namespace).Type("storage-engine device") != aeroconf.ValueStanza) {
-				cc.Stanza("namespace " + c.Namespace).Delete(key)
-			}
+		err := prepareNamespaceForDeviceStorage(&namespace)
+		if err != nil {
+			return err
 		}
-		if cc.Stanza("namespace "+c.Namespace).Type("storage-engine device") == aeroconf.ValueNil {
-			cc.Stanza("namespace " + c.Namespace).NewStanza("storage-engine device")
-		}
-		cc.Stanza("namespace " + c.Namespace).Stanza("storage-engine device").Delete("device")
-		cc.Stanza("namespace " + c.Namespace).Stanza("storage-engine device").Delete("file")
-		cc.Stanza("namespace " + c.Namespace).Stanza("storage-engine device").Delete("filesize")
 	case "shadow":
-		if cc.Stanza("namespace "+c.Namespace).Type("storage-engine device") != aeroconf.ValueStanza && cc.Stanza("namespace "+c.Namespace).Type("storage-engine memory") != aeroconf.ValueStanza {
-			return fmt.Errorf("storage-engine device|memory configuration not found for namespace")
+		if namespace.Type("storage-engine device") != aeroconf.ValueStanza && namespace.Type("storage-engine memory") != aeroconf.ValueStanza {
+			return fmt.Errorf("storage-engine device|memory configuration not found for namespace %s", c.Namespace)
 		}
-		if !inslice.HasString(cc.Stanza("namespace "+c.Namespace).Stanza("storage-engine device").ListKeys(), "device") && !inslice.HasString(cc.Stanza("namespace "+c.Namespace).Stanza("storage-engine memory").ListKeys(), "device") {
-			return fmt.Errorf("no device configured for given namespace, cannot add shadow devices")
+		if !inslice.HasString(namespace.Stanza("storage-engine device").ListKeys(), "device") && !inslice.HasString(namespace.Stanza("storage-engine memory").ListKeys(), "device") {
+			return fmt.Errorf("no devices are configured for namespace %s, cannot add shadow devices", c.Namespace)
 		}
-	case "allflash":
-		fallthrough
-	case "pi-flash":
-		if cc.Stanza("namespace "+c.Namespace).Type("index-type flash") == aeroconf.ValueStanza {
-			cc.Stanza("namespace " + c.Namespace).Stanza("index-type flash").Delete("mount")
-		}
-		for _, key := range cc.Stanza("namespace " + c.Namespace).ListKeys() {
-			if strings.HasPrefix(key, "index-type") && (!strings.HasSuffix(key, "flash") || cc.Stanza("namespace "+c.Namespace).Type("index-type flash") != aeroconf.ValueStanza) {
-				cc.Stanza("namespace " + c.Namespace).Delete(key)
-			}
-		}
-		if cc.Stanza("namespace "+c.Namespace).Type("index-type flash") == aeroconf.ValueNil {
-			cc.Stanza("namespace " + c.Namespace).NewStanza("index-type flash")
+	case "allflash", "pi-flash":
+		err := prepareNamespaceForIndexFlash(&namespace, "index-type")
+		if err != nil {
+			return err
 		}
 	case "si-flash":
-		if cc.Stanza("namespace "+c.Namespace).Type("sindex-type flash") == aeroconf.ValueStanza {
-			cc.Stanza("namespace " + c.Namespace).Stanza("sindex-type flash").Delete("mount")
+		err := prepareNamespaceForIndexFlash(&namespace, "sindex-type")
+		if err != nil {
+			return err
 		}
-		for _, key := range cc.Stanza("namespace " + c.Namespace).ListKeys() {
-			if strings.HasPrefix(key, "sindex-type") && (!strings.HasSuffix(key, "flash") || cc.Stanza("namespace "+c.Namespace).Type("sindex-type flash") != aeroconf.ValueStanza) {
-				cc.Stanza("namespace " + c.Namespace).Delete(key)
-			}
-		}
-		if cc.Stanza("namespace "+c.Namespace).Type("sindex-type flash") == aeroconf.ValueNil {
-			cc.Stanza("namespace " + c.Namespace).NewStanza("sindex-type flash")
-		}
+	default:
+		return fmt.Errorf("unknown device configuration type %s", c.ConfDest)
 	}
+
+	// Validate disk and partition counts, gather devices for configuration
 	diskCount := 0
-	useParts := []blockDevices{}
+	var useDevices []blockDevices
 	for _, parts := range disks {
 		if _, ok := parts[0]; !ok {
 			continue
@@ -219,149 +205,80 @@ func (c *clusterPartitionConfCmd) do(nodeNo int, disks map[int]map[int]blockDevi
 			} else if part.MountPoint == "" && (c.ConfDest == "pi-flash" || c.ConfDest == "si-flash" || c.ConfDest == "allflash") {
 				return fmt.Errorf("partition %d on disk %d on node %d does not have a filesystem, cannot use for all-flash storage", part.partNo, part.diskNo, part.nodeNo)
 			}
-			useParts = append(useParts, part)
+			useDevices = append(useDevices, part)
 		}
 	}
 	if c.FilterDisks != "ALL" && diskCount < filterDiskCount {
 		return fmt.Errorf("could not find all the required disks on node %d", nodeNo)
 	}
-	sort.Slice(useParts, func(x, y int) bool {
-		if useParts[x].diskNo < useParts[y].diskNo {
+	sort.Slice(useDevices, func(x, y int) bool {
+		if useDevices[x].diskNo < useDevices[y].diskNo {
 			return true
-		} else if useParts[x].diskNo > useParts[y].diskNo {
+		} else if useDevices[x].diskNo > useDevices[y].diskNo {
 			return false
 		} else {
-			return useParts[x].partNo < useParts[y].partNo
+			return useDevices[x].partNo < useDevices[y].partNo
 		}
 	})
+
+	assignFunc := func(vals []*string, device blockDevices) ([]*string, error) {
+		return append(vals, &device.Path), nil
+	}
+
+	// Assign devices
 	totalFsSizeBytes := 0
-	for _, p := range useParts {
+	for _, device := range useDevices {
 		switch c.ConfDest {
-		case "memory":
-			vals, err := cc.Stanza("namespace " + c.Namespace).Stanza("storage-engine memory").GetValues("device")
+		case "memory", "device":
+			err = assignStorageEngineDevice(&namespace, c.ConfDest, device, assignFunc)
 			if err != nil {
 				return err
 			}
-			pp := p.Path
-			vals = append(vals, &pp)
-			cc.Stanza("namespace "+c.Namespace).Stanza("storage-engine memory").SetValues("device", vals)
-		case "device":
-			vals, err := cc.Stanza("namespace " + c.Namespace).Stanza("storage-engine device").GetValues("device")
-			if err != nil {
-				return err
-			}
-			pp := p.Path
-			vals = append(vals, &pp)
-			cc.Stanza("namespace "+c.Namespace).Stanza("storage-engine device").SetValues("device", vals)
 		case "shadow":
 			ntype := "memory"
-			if cc.Stanza("namespace "+c.Namespace).Stanza("storage-engine device") != nil {
+			if namespace.Stanza("storage-engine device") != nil {
 				ntype = "device"
 			}
-			vals, err := cc.Stanza("namespace " + c.Namespace).Stanza("storage-engine " + ntype).GetValues("device")
+
+			err = assignStorageEngineDevice(&namespace, ntype, device, func(vals []*string, device blockDevices) ([]*string, error) {
+				found := false
+				for valI, val := range vals {
+					if len(strings.Split(*val, " ")) == 2 {
+						continue
+					}
+					found = true
+					newval := *val + " " + device.Path
+					vals[valI] = &newval
+					break
+				}
+				if !found {
+					return nil, errors.New("not enough primary devices for chosen shadow devices")
+				}
+
+				return vals, nil
+			})
+		case "allflash", "pi-flash":
+			err = assignFlashIndexDevice(&namespace, "index-type", device, isv7, c.MountsSizeLimitPct, c.ClusterName.String(), nodeNo, &totalFsSizeBytes)
 			if err != nil {
 				return err
 			}
-			found := false
-			for valI, val := range vals {
-				if len(strings.Split(*val, " ")) == 2 {
-					continue
-				}
-				found = true
-				newval := *val + " " + p.Path
-				vals[valI] = &newval
-				break
-			}
-			if !found {
-				return errors.New("not enough primary devices for chosen shadow devices")
-			}
-			cc.Stanza("namespace "+c.Namespace).Stanza("storage-engine "+ntype).SetValues("device", vals)
-		case "allflash":
-			fallthrough
-		case "pi-flash":
-			vals, err := cc.Stanza("namespace " + c.Namespace).Stanza("index-type flash").GetValues("mount")
-			if err != nil {
-				return err
-			}
-			if p.MountPoint == "" {
-				return fmt.Errorf("partition %d on disk %d on node %d does not have a mountpoint", p.partNo, p.diskNo, p.nodeNo)
-			}
-			pp := p.MountPoint
-			vals = append(vals, &pp)
-			cc.Stanza("namespace "+c.Namespace).Stanza("index-type flash").SetValues("mount", vals)
-			var fsSizeI int
-			if strings.Contains(p.FsSize, ".") {
-				var fsSizeF float64
-				fsSizeF, err = strconv.ParseFloat(strings.TrimRight(p.FsSize, "GMBTgmbti"), 64)
-				if err == nil {
-					fsSizeI = int(math.Floor(fsSizeF))
-				}
-			} else {
-				fsSizeI, err = strconv.Atoi(strings.TrimRight(p.FsSize, "GMBTgmbti"))
-			}
-			fsSize := p.FsSize
-			if err == nil {
-				if strings.HasSuffix(strings.ToUpper(p.FsSize), "G") {
-					totalFsSizeBytes += fsSizeI * 1024 * 1024 * 1024
-				} else if strings.HasSuffix(strings.ToUpper(p.FsSize), "M") {
-					totalFsSizeBytes += fsSizeI * 1024 * 1024
-				} else if strings.HasSuffix(strings.ToUpper(p.FsSize), "K") {
-					totalFsSizeBytes += fsSizeI * 1024
-				} else if strings.HasSuffix(strings.ToUpper(p.FsSize), "T") {
-					totalFsSizeBytes += fsSizeI * 1024 * 1024 * 1024 * 1024
-				} else {
-					totalFsSizeBytes += fsSizeI
-				}
-				maxUsableBytes := int(float64(totalFsSizeBytes) * c.MountsSizeLimitPct / 100)
-				fsSize = strconv.Itoa(maxUsableBytes/1024) + "K"
-			}
-			cc.Stanza("namespace "+c.Namespace).Stanza("index-type flash").SetValue(is7, fsSize)
 		case "si-flash":
-			vals, err := cc.Stanza("namespace " + c.Namespace).Stanza("sindex-type flash").GetValues("mount")
+			err = assignFlashIndexDevice(&namespace, "sindex-type", device, isv7, c.MountsSizeLimitPct, c.ClusterName.String(), nodeNo, &totalFsSizeBytes)
 			if err != nil {
 				return err
 			}
-			if p.MountPoint == "" {
-				return fmt.Errorf("partition %d on disk %d on node %d does not have a mountpoint", p.partNo, p.diskNo, p.nodeNo)
-			}
-			pp := p.MountPoint
-			vals = append(vals, &pp)
-			cc.Stanza("namespace "+c.Namespace).Stanza("sindex-type flash").SetValues("mount", vals)
-			var fsSizeI int
-			if strings.Contains(p.FsSize, ".") {
-				var fsSizeF float64
-				fsSizeF, err = strconv.ParseFloat(strings.TrimRight(p.FsSize, "GMBTgmbti"), 64)
-				if err == nil {
-					fsSizeI = int(math.Floor(fsSizeF))
-				}
-			} else {
-				fsSizeI, err = strconv.Atoi(strings.TrimRight(p.FsSize, "GMBTgmbti"))
-			}
-			fsSize := p.FsSize
-			if err == nil {
-				if strings.HasSuffix(strings.ToUpper(p.FsSize), "G") {
-					totalFsSizeBytes += fsSizeI * 1024 * 1024 * 1024
-				} else if strings.HasSuffix(strings.ToUpper(p.FsSize), "M") {
-					totalFsSizeBytes += fsSizeI * 1024 * 1024
-				} else if strings.HasSuffix(strings.ToUpper(p.FsSize), "K") {
-					totalFsSizeBytes += fsSizeI * 1024
-				} else if strings.HasSuffix(strings.ToUpper(p.FsSize), "T") {
-					totalFsSizeBytes += fsSizeI * 1024 * 1024 * 1024 * 1024
-				} else {
-					totalFsSizeBytes += fsSizeI
-				}
-				maxUsableBytes := int(float64(totalFsSizeBytes) * c.MountsSizeLimitPct / 100)
-				fsSize = strconv.Itoa(maxUsableBytes/1024) + "K"
-			}
-			cc.Stanza("namespace "+c.Namespace).Stanza("sindex-type flash").SetValue(is7, fsSize)
+		default:
+			return fmt.Errorf("unknown device configuration type %s", c.ConfDest)
 		}
 	}
+
+	// Validate and finalize configuration
 	if c.ConfDest == "shadow" {
 		ntype := "memory"
-		if cc.Stanza("namespace "+c.Namespace).Stanza("storage-engine device") != nil {
+		if namespace.Stanza("storage-engine device") != nil {
 			ntype = "device"
 		}
-		vals, err := cc.Stanza("namespace " + c.Namespace).Stanza("storage-engine " + ntype).GetValues("device")
+		vals, err := namespace.Stanza("storage-engine " + ntype).GetValues("device")
 		if err != nil {
 			return err
 		}
@@ -372,17 +289,18 @@ func (c *clusterPartitionConfCmd) do(nodeNo int, disks map[int]map[int]blockDevi
 			}
 		}
 	}
+
 	if (c.ConfDest == "allflash" || c.ConfDest == "pi-flash") && totalFsSizeBytes > 0 {
 		treeSprigs := "256"
 		rf := "2"
-		if cc.Stanza("namespace "+c.Namespace).Type("partition-tree-sprigs") != aeroconf.ValueNil {
-			sprigsconf, err := cc.Stanza("namespace " + c.Namespace).GetValues("partition-tree-sprigs")
+		if namespace.Type("partition-tree-sprigs") != aeroconf.ValueNil {
+			sprigsconf, err := namespace.GetValues("partition-tree-sprigs")
 			if err == nil && len(sprigsconf) > 0 {
 				treeSprigs = *sprigsconf[0]
 			}
 		}
-		if cc.Stanza("namespace "+c.Namespace).Type("replication-factor") != aeroconf.ValueNil {
-			rfconf, err := cc.Stanza("namespace " + c.Namespace).GetValues("replication-factor")
+		if namespace.Type("replication-factor") != aeroconf.ValueNil {
+			rfconf, err := namespace.GetValues("replication-factor")
 			if err == nil && len(rfconf) > 0 {
 				rf = *rfconf[0]
 			}
@@ -397,14 +315,16 @@ func (c *clusterPartitionConfCmd) do(nodeNo int, disks map[int]map[int]blockDevi
 		maxRecordsStr := p.Sprintf("%d", maxRecords)
 		if spaceRequired > maxUsableBytes {
 			log.Printf("WARNING: node=%d space required for partition-tree-sprigs (%s) exceeds the pi-flash partition_size*%d%% (%s). Changing from %d to %d. At %s master records the fill factor will be 1.", nodeNo, convSize(int64(spaceRequired)), int(c.MountsSizeLimitPct), convSize(int64(maxUsableBytes)), treeSprigsInt, maxSprigs, maxRecordsStr)
-			cc.Stanza("namespace "+c.Namespace).SetValue("partition-tree-sprigs", strconv.Itoa(maxSprigs))
+			namespace.SetValue("partition-tree-sprigs", strconv.Itoa(maxSprigs))
 		} else if maxSprigs > treeSprigsInt {
 			log.Printf("WARNING: node=%d partition-tree-sprigs seems to be low for the amount of partition space configured (%s). Changing from %d to %d. At %s master records the fill factor will be 1.", nodeNo, convSize(int64(maxUsableBytes)), treeSprigsInt, maxSprigs, maxRecordsStr)
-			cc.Stanza("namespace "+c.Namespace).SetValue("partition-tree-sprigs", strconv.Itoa(maxSprigs))
+			namespace.SetValue("partition-tree-sprigs", strconv.Itoa(maxSprigs))
 		}
 	}
+
+	// Write out the new config file
 	var buf bytes.Buffer
-	err = cc.Write(&buf, "", "    ", true)
+	err = conf.Write(&buf, "", "    ", true)
 	if err != nil {
 		return err
 	}
@@ -413,6 +333,183 @@ func (c *clusterPartitionConfCmd) do(nodeNo int, disks map[int]map[int]blockDevi
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func assignStorageEngineDevice(namespace *aeroconf.Stanza, deviceType string, device blockDevices, assign func([]*string, blockDevices) ([]*string, error)) error {
+	if namespace == nil {
+		return fmt.Errorf("namespace stanza is nil")
+	}
+
+	deviceStanza := namespace.Stanza("storage-engine " + deviceType)
+	if deviceStanza == nil {
+		return fmt.Errorf("namespace does not contain storage-engine %s stanza", deviceType)
+	}
+
+	vals, err := deviceStanza.GetValues("device")
+	if err != nil {
+		return err
+	}
+
+	vals, err = assign(vals, device)
+	if err != nil {
+		return err
+	}
+
+	return deviceStanza.SetValues("device", vals)
+}
+
+func assignFlashIndexDevice(namespace *aeroconf.Stanza, indexType string, device blockDevices, is7 bool, mountsSizeLimitPct float64, clusterName string, nodeNo int, totalFsSizeBytes *int) error {
+	if namespace == nil {
+		return fmt.Errorf("namespace stanza is nil")
+	}
+
+	indexStanza := namespace.Stanza(indexType + " flash")
+	if indexStanza == nil {
+		return fmt.Errorf("namespace does not contain %s flash stanza", indexType)
+	}
+
+	vals, err := indexStanza.GetValues("mount")
+	if err != nil {
+		return err
+	}
+
+	if device.MountPoint == "" {
+		return fmt.Errorf("partition %d on disk %d on node %d does not have a mountpoint", device.partNo, device.diskNo, device.nodeNo)
+	}
+
+	pp := device.MountPoint
+	vals = append(vals, &pp)
+	err = indexStanza.SetValues("mount", vals)
+	if err != nil {
+		return err
+	}
+
+	var fsSizeI int
+	if strings.Contains(device.FsSize, ".") {
+		var fsSizeF float64
+		fsSizeF, err = strconv.ParseFloat(strings.TrimRight(device.FsSize, "GMBTgmbti"), 64)
+		if err == nil {
+			fsSizeI = int(math.Floor(fsSizeF))
+		}
+	} else {
+		fsSizeI, err = strconv.Atoi(strings.TrimRight(device.FsSize, "GMBTgmbti"))
+	}
+	if err == nil {
+		if strings.HasSuffix(strings.ToUpper(device.FsSize), "T") {
+			*totalFsSizeBytes += fsSizeI * 1024 * 1024 * 1024 * 1024
+		} else if strings.HasSuffix(strings.ToUpper(device.FsSize), "G") {
+			*totalFsSizeBytes += fsSizeI * 1024 * 1024 * 1024
+		} else if strings.HasSuffix(strings.ToUpper(device.FsSize), "M") {
+			*totalFsSizeBytes += fsSizeI * 1024 * 1024
+		} else if strings.HasSuffix(strings.ToUpper(device.FsSize), "K") {
+			*totalFsSizeBytes += fsSizeI * 1024
+		} else {
+			*totalFsSizeBytes += fsSizeI
+		}
+		// Need to get the device size from the node directly
+	} else {
+		outn, err := b.RunCommands(clusterName, [][]string{{"blockdev", "--getsize64", device.Path}}, []int{nodeNo})
+		if err == nil {
+			if len(outn) != 1 {
+				err = fmt.Errorf("expected out string from one command, got %d", len(outn))
+			} else {
+				fsSize := strings.Trim(string(outn[0]), "\r\t\n")
+				fsSizeI, err = strconv.Atoi(fsSize)
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("could not determine the size of %s on node %d: %v", device.Path, nodeNo, err)
+		}
+		*totalFsSizeBytes += fsSizeI
+	}
+
+	maxUsableBytes := int(float64(*totalFsSizeBytes) * mountsSizeLimitPct / 100)
+	fsSize := strconv.Itoa(maxUsableBytes/1024) + "K"
+
+	// This configuration setting has changed as of v7.x to mounts-budget
+	mountsConfig := "mounts-size-limit"
+	if is7 {
+		mountsConfig = "mounts-budget"
+	}
+
+	return indexStanza.SetValue(mountsConfig, fsSize)
+}
+
+func prepareNamespaceForMemoryStorage(namespace *aeroconf.Stanza) error {
+	if namespace == nil {
+		return fmt.Errorf("namespace stanza is nil")
+	}
+
+	for _, key := range namespace.ListKeys() {
+		if strings.HasPrefix(key, "storage-engine") && !strings.HasSuffix(key, "memory") {
+			_ = namespace.Delete(key)
+		}
+	}
+
+	if namespace.Type("storage-engine memory") == aeroconf.ValueNil {
+		err := namespace.NewStanza("storage-engine memory")
+		if err != nil {
+			return fmt.Errorf("could not create stanza for memory storage: %v", err)
+		}
+	}
+
+	memoryStanza := namespace.Stanza("storage-engine memory")
+	_ = memoryStanza.Delete("device")
+	_ = memoryStanza.Delete("file")
+	_ = memoryStanza.Delete("filesize")
+	_ = memoryStanza.Delete("data-size")
+
+	return nil
+}
+
+func prepareNamespaceForDeviceStorage(namespace *aeroconf.Stanza) error {
+	if namespace == nil {
+		return fmt.Errorf("namespace stanza is nil")
+	}
+
+	for _, key := range namespace.ListKeys() {
+		if strings.HasPrefix(key, "storage-engine") && (!strings.HasSuffix(key, "device") || namespace.Type("storage-engine device") != aeroconf.ValueStanza) {
+			_ = namespace.Delete(key)
+		}
+	}
+
+	if namespace.Type("storage-engine device") == aeroconf.ValueNil {
+		err := namespace.NewStanza("storage-engine device")
+		if err != nil {
+			return fmt.Errorf("could not create stanza for device storage: %v", err)
+		}
+	}
+
+	deviceStanza := namespace.Stanza("storage-engine device")
+	_ = deviceStanza.Delete("device")
+	_ = deviceStanza.Delete("file")
+	_ = deviceStanza.Delete("filesize")
+
+	return nil
+}
+
+func prepareNamespaceForIndexFlash(namespace *aeroconf.Stanza, indexTypePrefix string) error {
+	if namespace == nil {
+		return fmt.Errorf("namespace stanza is nil")
+	}
+
+	for _, key := range namespace.ListKeys() {
+		if strings.HasPrefix(key, indexTypePrefix) && (!strings.HasSuffix(key, "flash") || namespace.Type(indexTypePrefix+" flash") != aeroconf.ValueStanza) {
+			_ = namespace.Delete(key)
+		}
+	}
+
+	if namespace.Type(indexTypePrefix+" flash") == aeroconf.ValueNil {
+		err := namespace.NewStanza(indexTypePrefix + " flash")
+		if err != nil {
+			return err
+		}
+	}
+
+	indexStanza := namespace.Stanza(indexTypePrefix + " flash")
+	_ = indexStanza.Delete("mount")
+
 	return nil
 }
 

--- a/src/cmdClusterPartitionCreate.go
+++ b/src/cmdClusterPartitionCreate.go
@@ -109,8 +109,9 @@ func (c *clusterPartitionCreateCmd) Execute(args []string) error {
 					script.Add("set +e")
 					script.Add("RET=0; while [ $RET -eq 0 ]; do mount |egrep '^" + p.Path + "( |\\t)'; RET=$?; sleep 1; done")
 					script.Add("set -e")
+					script.Add("sed -i.bak -e 's~.*" + p.MountPoint + ".*~~g' /etc/fstab || echo 'not mounted'")
+					script.Add("rm -rf " + p.MountPoint)
 				}
-				script.Add("sed -i.bak -e 's~" + p.Path + ".*~~g' /etc/fstab || echo 'not mounted'")
 			}
 			if len(part) > 1 {
 				script.Add("sleep 1; parted -s " + part[0].Path + " 'mktable gpt'")

--- a/src/cmdClusterPartitionList.go
+++ b/src/cmdClusterPartitionList.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -96,6 +97,9 @@ func (c *clusterPartitionListCmd) fixPartOut(bd []blockDevices, blkFormat int) [
 		bd[i].Size = strings.Trim(bd[i].Size, "\t\r\n ")
 		bd[i].Type = strings.Trim(bd[i].Type, "\t\r\n ")
 		bd[i].PartUUID = strings.Trim(bd[i].PartUUID, "\t\r\n ")
+		if bd[i].PartUUID != "" {
+			bd[i].PartUUIDPath = path.Join("/dev/disk/by-partuuid", bd[i].PartUUID)
+		}
 		if blkFormat == 2 {
 			bd[i].Path = bd[i].Name
 			bd[i].FsSize = "N/A"


### PR DESCRIPTION
Because certain cloud providers don't guarantee that devices will enumerate in
a consistent order, use the PARTUUID instead of the device when working with
partitions.

This will result in an aerospike namespace config that looks like this:

```
namespace test {
    default-ttl 0
    index-type flash {
        mount /mnt/05f452fc-e059-4f0f-aad7-ece9b0528f51
        mount /mnt/7b484aac-6166-49c9-b710-6c165cbf9a52
        mount /mnt/aa9e5735-0840-403e-b5d4-06fff5f63313
        mount /mnt/15d84ea5-4f58-415f-a275-eef72ef8f927
        mounts-budget 279340646K
    }
    partition-tree-sprigs 8192
    replication-factor 2
    sindex-type flash {
        mount /mnt/15f452fc-e059-4f0f-aad7-ece9b0528f42
        mount /mnt/6b484aac-6166-49c9-b710-6c165cbf9a42
        mount /mnt/3a9e5735-0840-403e-b5d4-06fff5f63338
        mount /mnt/85d84ea5-4f58-415f-a275-eef72ef8f919
        mounts-budget 279340646K
    }
    storage-engine device {
        device /dev/disk/by-partuuid/7b3398e7-2c44-4d1e-a9d4-d8a7306f0981 /dev/disk/by-partuuid/85244191-e8ff-4efa-8e01-becde33901f0
        device /dev/disk/by-partuuid/89856114-3dec-44d8-8516-7453ddc2cf54 /dev/disk/by-partuuid/8439ce70-c9dc-4c1d-a49d-0a516e7e37bc
        device /dev/disk/by-partuuid/7319fe45-bc39-41a8-b584-b1a939b292f6 /dev/disk/by-partuuid/d6ad47e0-31ae-4c23-b705-a4d861a2b6d3
        device /dev/disk/by-partuuid/7844dbd3-ab9a-4c0e-a45e-5a2fbe8cb76e /dev/disk/by-partuuid/c79f2053-6d7a-4c87-aa65-3d252ad34dc6
        device /dev/disk/by-partuuid/cbac86d4-339b-462c-9d2a-afe074918c19 /dev/disk/by-partuuid/024b50a1-b05f-448d-8c85-131e8cd8b487
        device /dev/disk/by-partuuid/0beb84fa-ec6a-4988-a4e6-e03d26ae9af8 /dev/disk/by-partuuid/aa7e38f5-f897-4b13-9154-65f271d4acbc
        device /dev/disk/by-partuuid/78bc332c-7921-45d9-8372-5cd7de749936 /dev/disk/by-partuuid/654b64b3-1d2d-4a1e-9af1-8c05939acefd
        device /dev/disk/by-partuuid/94b5c2c9-9814-4c2b-8dde-43d7a97c2191 /dev/disk/by-partuuid/650042f6-96ef-4692-8236-38deabdf0765
    }
}