### PR TITLE
[tiger] is the network incorrectly setting region or is there anothe

### DIFF
--- a/src/cli/cmd/v1/cmdInstancesCreate.go
+++ b/src/cli/cmd/v1/cmdInstancesCreate.go
@@ -768,9 +768,13 @@ func (c *InstancesCreateCmd) CreateInstances(system *System, inventory *backends
 	if parseErr != nil {
 		return nil, fmt.Errorf("invalid --docker-swap-limit: %w", parseErr)
 	}
+	dockerNetworkPlacement := ""
+	if c.Docker.NetworkName != "" {
+		dockerNetworkPlacement = "," + c.Docker.NetworkName
+	}
 	dockerParams := &bdocker.CreateInstanceParams{
 		Image:             nil,
-		NetworkPlacement:  c.Docker.NetworkName,
+		NetworkPlacement:  dockerNetworkPlacement,
 		Disks:             c.Docker.Disks,
 		Firewalls:         c.Docker.ExposePorts,
 		Cmd:               strslice.StrSlice{},


### PR DESCRIPTION
Draft PR opened by **Tiger** (automated agent). Review before merging.

**Repo:** `aerolab`  
**Base:** `v8.0.0`

**Requested task:**
> is the network incorrectly setting region or is there another issue? is custom-network feature supported on docker?
```asx311  jkim  ~  qe  aerospike-tests-asx   CLIENT-5039-CLIENT-5040  5✎  1⚑  ERROR  aerolab config docker list-networks
2026/07/08 11:27:13 INFO [config.docker.list-networks] Initializing backend
2026/07/08 11:27:13 INFO [config.docker.list-networks] Running config.docker.list-networks
 NETWORKS
 Backend  Name         CIDR           Driver  MTU    NetID
 docker   bridge       172.17.0.0/16  bridge  65535  c7224d89eab0ff2bd31d0f1abbedfa2399ab994fd34c4a9eb8945abf9ac94f46
 docker   test-runner  172.18.0.0/16  bridge         a4d91d62a87e5f48a643d89c417a76017823b2167d67182153059e98ae641e87
 docker   host                        host           42a1a562122d0da50734cb34d81721a9762abdef7d967f0399beb3339ca75e76
 docker   none                        null           98bff36f08b544243f134d77333f21c2b1fa8f3b08d89d03fd4d024015c79efe

2026/07/08 11:27:13 INFO [config.docker.list-networks] Done
 asx311  jkim  ~  qe  aerospike-tests-asx   CLIENT-5039-CLIENT-5040  5✎  1⚑  aerolab cluster create -c 3 --network=test-runner
2026/07/08 11:27:21 INFO [cluster.create] Initializing backend
2026/07/08 11:27:21 INFO [cluster.create] Running cluster.create
2026/07/08 11:27:22 INFO [cluster.create] Features file: /Users/jkim/qe/qe-tools/test/scenarios2/data/features/features.conf
2026/07/08 11:27:22 INFO [cluster.create] Aerospike Version: 8.1.2.3, Flavor: enterprise, Distro: ubuntu, OS Version: 22.04, Arch: arm64
2026/07/08 11:27:22 INFO [cluster.create] Creating instances, this may take a while...
2026/07/08 11:27:22 ERROR [cluster.create] region test-runner not found```

**Tiger's summary:**

## Answer

It's a bug, not a network/region misconfiguration on your end — and yes, custom Docker networks are supposed to be supported.

**What's happening:** `--network` is a real, valid feature, but `cluster create`/`instances create` (docker backend) had a wiring bug. `bdocker`'s internal `NetworkPlacement` field is meant to be a `"serverName,networkName"` pair (docker supports multiple daemon "regions"/hosts, unrelated to actual Docker networks). The CLI code at `cmdInstancesCreate.go:773` was passing your bare `--network` value straight through with no comma, so the parser in `bdocker/instances.go` misread `test-runner` as the **server/region alias** (first field) instead of the network name (second field). Since no docker "region" named `test-runner` is configured (regions are docker daemon endpoints from `regions.json`, defaulting to just `["default"]"`), it failed with `region test-runner not found` — completely unrelated to your actual Docker network, which is fine and was found correctly by `list-networks`.

This affected **any** non-default network name — including ones created via `aerolab config docker create-network` — not just externally-created ones. It only "worked" when `--network` was left empty, because that skipped the broken parsing path entirely.

**Fix applied** (commit `dbc872e0`): `cmdInstancesCreate.go` now builds `NetworkPlacement` as `","+NetworkName` when a network is given (empty otherwise, to keep the no-flag default path unchanged). This is the single call site used by `cluster create`, `instances create`, and `agi create`, so all three are fixed.

I couldn't run `go build`/tests since Go isn't installed in this sandbox — worth a quick local build/smoke test (`aerolab cluster create -c 3 --network=test-runner`) before merging.
