### PR TITLE
[tiger] fix 1 and 2 please

### DIFF
--- a/src/pkg/backend/clouds/bdocker/instances.go
+++ b/src/pkg/backend/clouds/bdocker/instances.go
@@ -577,8 +577,8 @@ func (s *b) refreshStartedInstances(cli *client.Client, ids []string, instances 
 			for _, n := range c.NetworkSettings.Networks {
 				if n != nil && n.IPAddress != "" {
 					inst.IP.Private = n.IPAddress
+					break
 				}
-				break
 			}
 		}
 	}

--- a/src/tests/e2e/cloud_test.go
+++ b/src/tests/e2e/cloud_test.go
@@ -41,6 +41,17 @@ func TestCloudSecretsLifecycle(t *testing.T) {
 
 	var sl secretsList
 	mustJSON(t, c.run("cloud", "secrets", "list", "-o", "json"), &sl)
+
+	// Clean up every secret we own with our marker description, registered
+	// before the assertion below so it still runs if the assertion fails.
+	t.Cleanup(func() {
+		for _, s := range sl.Secrets {
+			if s.Description == "aerolab" {
+				c.run("cloud", "secrets", "delete", "--secret-id", s.ID)
+			}
+		}
+	})
+
 	found := 0
 	for _, s := range sl.Secrets {
 		if s.Description == "aerolab" {
@@ -49,13 +60,6 @@ func TestCloudSecretsLifecycle(t *testing.T) {
 	}
 	if found < 1 {
 		t.Fatalf("expected at least one 'aerolab' secret, got %d", found)
-	}
-
-	// Clean up every secret we own with our marker description.
-	for _, s := range sl.Secrets {
-		if s.Description == "aerolab" {
-			c.run("cloud", "secrets", "delete", "--secret-id", s.ID)
-		}
 	}
 }
 


### PR DESCRIPTION
Draft PR opened by **Tiger** (automated agent). Review before merging.

**Repo:** `aerolab`  
**Base:** `v8.0.0`

**Requested task:**
> fix 1 and 2 please

**Tiger's summary:**

Both fixes are committed (`50ef0d5d`):

1. **`bdocker/instances.go`** — moved `break` inside the `if n.IPAddress != ""` check so the loop now keeps scanning networks until it finds one with an IP, instead of stopping after the first (random) network regardless of whether it had an address.
2. **`src/tests/e2e/cloud_test.go`** — the secret cleanup is now registered via `t.Cleanup` right after the secret is created/listed, so it still runs even if the `found < 1` assertion fails, preventing a leaked secret in the cloud test account.

No Go toolchain is available in this sandbox to compile/test-verify, so I checked both diffs manually for correctness — they're small, isolated, and syntactically clean.
