### PR TITLE
[tiger] continue please

### DIFF
--- a/docs/commands/aerospike.md
+++ b/docs/commands/aerospike.md
@@ -239,15 +239,18 @@ aerolab aerospike is-stable
 
 ### Options
 
-| Option | Description |
-|--------|-------------|
-| `-n, --name` | Cluster name |
-| `-l, --nodes` | Node list |
-| `-w, --wait` | Wait for stability |
-| `-o, --timeout` | Timeout in seconds (0 = no timeout) | `0` |
-| `-i, --ignore-migrations` | Ignore migrations when checking stability |
-| `--namespace` | Namespace to check (default: all) |
-| `-v, --verbose` | Verbose output |
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-n, --name` | Cluster name(s), comma separated, or `all` | `mydc` |
+| `-l, --nodes` | Only consider the given nodes, e.g. `--nodes=1-4,7,8` | (all) |
+| `-w, --wait` | Wait for stability | |
+| `-o, --wait-timeout` | Timeout in seconds for `-w` (0 = no timeout) | `0` |
+| `-i, --ignore-migrations` | Ignore migrations when checking stability | |
+| `-k, --ignore-cluster-key` | Do not check that the cluster key matches on all nodes | |
+| `-c, --not-cluster-key` | If this cluster key is matched, treat it as no-match | |
+| `-m, --namespace` | Namespace to check | `test` |
+| `-t, --threads` | Threads to use | `10` |
+| `-v, --verbose` | Verbose output | |
 
 ### Examples
 
@@ -273,7 +276,7 @@ aerolab aerospike is-stable -n mydc -w -o 30 -i
 
 **Check specific namespace:**
 ```bash
-aerolab aerospike is-stable -n mydc --namespace test
+aerolab aerospike is-stable -n mydc -m test
 ```
 
 ### Output

--- a/docs/commands/attach.md
+++ b/docs/commands/attach.md
@@ -19,8 +19,8 @@ All attach commands support these common options:
 | Option | Description |
 |--------|-------------|
 | `-n, --name` | Cluster name (comma-separated for multiple) |
-| `-l, --nodes` | Node list (`all` for all nodes, ranges like `1-3`) |
-| `--parallel` | Execute in parallel on all nodes |
+| `-l, --node` | Node list (`all` for all nodes, ranges like `1-3`) |
+| `-p, --parallel` | Execute in parallel on all nodes |
 
 ## Attach Shell
 

--- a/docs/commands/client.md
+++ b/docs/commands/client.md
@@ -6,13 +6,15 @@ Client commands enable you to create and manage client machines for various purp
 
 - `client create` - Create new client machines (none, base, tools, ams, vscode, graph, eksctl)
 - `client grow` - Add machines to existing client groups
-- `client configure` - Configure client machines (ams, firewall, tools)
+- `client configure` - Configure client machines (ams, firewall, tools, expiry)
+- `client template` - Manage client template images (pre-built images for faster client creation)
 - `client list` - List all client machine groups
 - `client start` - Start client machines
 - `client stop` - Stop client machines
 - `client destroy` - Destroy client machines
 - `client attach` - Attach to a client machine (shorthand for `attach client`)
 - `client share` - Share client access via SSH public key
+- `client update-hosts-file` - Update the hosts file on client machines
 
 ## Client Types
 
@@ -20,35 +22,35 @@ Client commands enable you to create and manage client machines for various purp
 Vanilla OS image with no modifications. Useful for custom setups.
 
 ```bash
-aerolab client create none -n myclient -d ubuntu -i 24.04
+aerolab client create none -n myclient --os ubuntu --version 24.04
 ```
 
 ### Base
 Simple base image with basic tools installed.
 
 ```bash
-aerolab client create base -n myclient -d ubuntu -i 24.04
+aerolab client create base -n myclient --os ubuntu --version 24.04
 ```
 
 ### Tools
 Aerospike tools (asbench, asadm, asinfo, asloglatency) pre-installed.
 
 ```bash
-aerolab client create tools -n tools -d ubuntu -i 24.04
+aerolab client create tools -n tools --os ubuntu --version 24.04
 ```
 
 ### AMS
 Aerospike Monitoring Stack with Prometheus, Grafana, and Loki.
 
 ```bash
-aerolab client create ams -n ams -d ubuntu -i 24.04 \
+aerolab client create ams -n ams --os ubuntu --version 24.04 \
   -s mycluster -S graph-client
 ```
 
 **AMS Options:**
 - `--grafana-version` - Grafana version (default: `latest`)
 - `--prometheus-version` - Prometheus version (default: `latest`)
-| `-s, --clusters` | Clusters to monitor (comma-separated) |
+- `-s, --clusters` - Clusters to monitor (comma-separated)
 - `-S, --clients` - Graph clients to monitor (comma-separated)
 - `--dashboards` - Custom dashboards YAML file
 - `--debug-dashboards` - Enable debug output for dashboard installation
@@ -57,22 +59,25 @@ aerolab client create ams -n ams -d ubuntu -i 24.04 \
 VSCode Server for browser-based development.
 
 ```bash
-aerolab client create vscode -n ide -d ubuntu -i 24.04
+aerolab client create vscode -n ide --os ubuntu --version 24.04
 ```
 
 ### Graph
 Graph database client for Aerospike Graph.
 
 ```bash
-aerolab client create graph -n graph -d ubuntu -i 24.04 \
-  -s mycluster
+aerolab client create graph -n graph --os ubuntu --version 24.04 \
+  -C mycluster
 ```
+
+`-C, --cluster-name` seeds the graph service from an existing Aerospike
+cluster (default: `mydc`); use `--seed` instead to point at a raw `IP:PORT`.
 
 ### EksCtl
 Client machine with eksctl pre-configured for Kubernetes Aerospike deployments.
 
 ```bash
-aerolab client create eksctl -n k8s-admin -d ubuntu -i 24.04
+aerolab client create eksctl -n k8s-admin --os ubuntu --version 24.04
 ```
 
 ---
@@ -84,65 +89,68 @@ Create new client machines.
 ### Basic Usage
 
 ```bash
-aerolab client create <type> -n <name> -d <distro> -i <version> [options]
+aerolab client create <type> -n <name> --os <distro> --version <version> [options]
 ```
 
 ### Common Options
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-n, --name` | Client group name | `client` |
+| `-n, --group-name` | Client group name | `client` |
 | `-c, --count` | Number of client machines | `1` |
-| `-d, --distro` | Distribution (ubuntu, centos, rocky, debian, amazon) | Required |
-| `-i, --distro-version` | Distribution version | Required |
+| `--os` | OS distribution (ubuntu, centos, rocky, debian, amazon) | `ubuntu` |
+| `--version` | OS version (e.g., `24.04`, `22.04`) | `24.04` |
 | `--type-override` | Override auto-detected client type | (empty) |
-| `-P, --parallel-threads` | Number of parallel threads | `10` |
+| `--threads` | Number of parallel threads | `10` |
+| `-t, --tag` | Tags to add, format `k=v` (can be specified multiple times) | |
+
+**Note:** Backend-specific options are grouped under a namespace, so each flag
+is prefixed with `aws.`, `gcp.`, or `docker.` (e.g. `--aws.instance`, not
+`--instance-type`) — the same pattern used by [`instances create`](instances.md#instances-create).
 
 ### Docker Backend Options
 
 ```bash
-aerolab client create tools -n tools -d ubuntu -i 24.04 \
-  -c 2 --docker-expose 9100:9100
+aerolab client create tools -n tools --os ubuntu --version 24.04 \
+  -c 2 --docker.expose 9100:9100
 ```
 
 | Option | Description |
 |--------|-------------|
-| `--docker-expose` | Expose ports (format: `host:container` or `+host:container` for cumulative) |
+| `--docker.expose` | Expose ports (format: `[+]{hostPort}:{containerPort}`; `+` maps to next available port) |
+| `--docker.network` | Docker network name to attach to (default: `default`) |
 
 ### AWS Backend Options
 
 ```bash
-aerolab client create tools -n tools -d ubuntu -i 24.04 \
-  -I t3a.medium --aws-disk type=gp3,size=20 --aws-expire=4h
+aerolab client create tools -n tools --os ubuntu --version 24.04 \
+  --aws.instance t3a.medium --aws.disk type=gp3,size=20 --aws.expire=4h
 ```
 
 | Option | Description |
 |--------|-------------|
-| `-I, --instance-type` | Instance type (e.g., `t3a.medium`) |
-| `--aws-disk` | Disk spec: `type={gp3\|gp2},size={GB}[,count=N]` |
-| `--aws-expire` | Expiry time (e.g., `4h`, `30m`) |
-| `-U, --subnet-id` | Subnet ID or availability zone |
-| `-L, --public-ip` | Enable public IP |
-| `--secgroup-name` | Security group names |
-| `--tags` | Custom tags (format: `key=value`) |
+| `--aws.instance` | Instance type (e.g., `t3a.medium`) |
+| `--aws.disk` | Disk spec: `type={gp3\|gp2\|io2\|io1},size={GB}[,count=N]` |
+| `--aws.expire` | Expiry time (e.g., `4h`, `30m`) |
+| `--aws.placement` | Subnet ID, availability zone, or region |
+| `--aws.no-public-ip` | Disable public IP assignment |
+| `--aws.firewall` | Extra security group names |
 
 ### GCP Backend Options
 
 ```bash
-aerolab client create tools -n tools -d ubuntu -i 24.04 \
-  --instance e2-medium --gcp-disk type=pd-ssd,size=20
+aerolab client create tools -n tools --os ubuntu --version 24.04 \
+  --gcp.instance e2-medium --gcp.disk type=pd-ssd,size=20
 ```
 
 | Option | Description |
 |--------|-------------|
-| `--instance` | Instance type (e.g., `e2-medium`) |
-| `--zone` | Zone name (e.g., `us-central1-a`) |
-| `--gcp-disk` | Disk spec: `type=pd-ssd[,size={GB}][,count=N]` |
-| `--gcp-expire` | Expiry time |
-| `--external-ip` | Enable public IP |
-| `--firewall` | Firewall rule names |
-| `--label` | Custom labels |
-| `--tag` | Network tags |
+| `--gcp.instance` | Instance type (e.g., `e2-medium`) |
+| `--gcp.zone` | Zone name (e.g., `us-central1-a`) |
+| `--gcp.disk` | Disk spec: `type=pd-ssd[,size={GB}][,count=N]` |
+| `--gcp.expire` | Expiry time |
+| `--gcp.no-public-ip` | Disable public IP assignment |
+| `--gcp.firewall` | Firewall rule names |
 
 ---
 
@@ -247,6 +255,19 @@ aerolab client configure tools -n tools -m ams
 aerolab client configure tools -n tools -l 1,2 -m my-ams
 ```
 
+### Configure Expiry
+
+Change (or remove) the expiry time of client machines (AWS/GCP only).
+
+```bash
+aerolab client configure expiry -n tools -e 24h
+```
+
+**Options:**
+- `-n, --group-name` - Client group name (default: `client`)
+- `-l, --machines` - Specific machines (default: all)
+- `-e, --expiry` - Expiry duration from now, e.g. `1D12h`, `2W`, `1Y6M` (default: `30h`; use `0` to remove expiry)
+
 ---
 
 ## Client List
@@ -334,22 +355,39 @@ Share client access with other users via SSH public key.
 ### Basic Usage
 
 ```bash
-aerolab client share -n tools -k ~/.ssh/id_rsa.pub
+aerolab client share -n tools -f ~/.ssh/id_rsa.pub
 ```
 
 **Options:**
-- `-n, --group-name` - Client group name
-- `-l, --machines` - Specific machines (default: all)
-- `-k, --key-file` - SSH public key file path
+- `-n, --name` - Client name (default: `client`)
+- `-f, --pubkey` - Path to the SSH public key to import
+- `-p, --parallel-threads` - Number of parallel threads (default: `10`)
+
+**Note:** unlike `configure`/`start`/`stop`/`destroy`, `client share` has no
+`-l, --machines` filter — it applies to every machine in the named group(s).
 
 **Example:**
 ```bash
-# Share access to all machines
-aerolab client share -n ams -k ~/.ssh/team_key.pub
+# Share access to all machines in the ams group
+aerolab client share -n ams -f ~/.ssh/team_key.pub
 
-# Share with specific machines
-aerolab client share -n tools -l 1,2 -k ~/.ssh/developer.pub
+# Share with multiple groups
+aerolab client share -n tools,ams -f ~/.ssh/developer.pub
 ```
+
+---
+
+## Client Update Hosts File
+
+Update the /etc/hosts file on client machines with cluster information.
+
+```bash
+aerolab client update-hosts-file
+```
+
+**Options:** `-o, --on` (update hosts file only on these clusters), `-w, --with`
+(include only instances from these clusters in the generated file); both
+default to all clusters.
 
 ---
 
@@ -365,10 +403,10 @@ aerolab cluster create -n prod -c 3 -d ubuntu -i 24.04 -v '8.*'
 aerolab cluster add exporter -n prod
 
 # 3. Create AMS client
-aerolab client create ams -n ams -d ubuntu -i 24.04 -s prod
+aerolab client create ams -n ams --os ubuntu --version 24.04 -s prod
 
 # 4. Create tools client for benchmarking
-aerolab client create tools -n tools -d ubuntu -i 24.04
+aerolab client create tools -n tools --os ubuntu --version 24.04
 
 # 5. Configure tools to send logs to AMS
 aerolab client configure tools -n tools -m ams
@@ -383,16 +421,16 @@ aerolab client list
 
 ```bash
 # Create VSCode IDE client
-aerolab client create vscode -n ide -d ubuntu -i 24.04
+aerolab client create vscode -n ide --os ubuntu --version 24.04
 
 # Create tools client
-aerolab client create tools -n dev-tools -d ubuntu -i 24.04
+aerolab client create tools -n dev-tools --os ubuntu --version 24.04
 
 # Create graph client
-aerolab client create graph -n graph-dev -d ubuntu -i 24.04 -s mycluster
+aerolab client create graph -n graph-dev --os ubuntu --version 24.04 -C mycluster
 
 # Share access with team
-aerolab client share -n ide,dev-tools,graph-dev -k ~/.ssh/team.pub
+aerolab client share -n ide,dev-tools,graph-dev -f ~/.ssh/team.pub
 ```
 
 ### Multi-Region XDR with Monitoring
@@ -406,7 +444,7 @@ aerolab xdr create-clusters -n us-east -N eu-west,ap-south \
 aerolab cluster add exporter -n us-east,eu-west,ap-south
 
 # Create AMS for monitoring all regions
-aerolab client create ams -n global-ams -d ubuntu -i 24.04 \
+aerolab client create ams -n global-ams --os ubuntu --version 24.04 \
   -s us-east,eu-west,ap-south
 
 # Access monitoring
@@ -417,7 +455,7 @@ aerolab client list
 
 ```bash
 # Create eksctl client
-aerolab client create eksctl -n k8s-admin -d ubuntu -i 24.04
+aerolab client create eksctl -n k8s-admin --os ubuntu --version 24.04
 
 # Attach to client
 aerolab client attach -n k8s-admin -l 1

--- a/docs/commands/cluster.md
+++ b/docs/commands/cluster.md
@@ -15,6 +15,7 @@ Cluster management commands allow you to create, manage, and operate Aerospike c
 - `cluster partition` - Manage disk partitions for clusters
 - `cluster attach` - Attach to cluster nodes (shorthand for `attach shell`)
 - `cluster share` - Share cluster access via SSH public key
+- `cluster update-hosts-file` - Update the hosts file on cluster nodes
 
 ## Cluster Create
 
@@ -40,12 +41,20 @@ aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*'
 | `-o, --customconf` | Custom aerospike config file path | |
 | `-z, --toolsconf` | Custom astools config file path | |
 | `-m, --mode` | Heartbeat mode (mcast/mesh/default) | `mesh` |
-| `-P, --parallel-threads` | Number of parallel threads | `10` |
+| `-p, --parallel-threads` | Number of parallel threads | `10` |
 
 ### Docker Backend
 
 ```bash
 aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*'
+```
+
+**Docker Options:**
+- `--network` - Name of a non-default Docker network to attach the nodes to. Manage networks with `aerolab config docker list-networks` / `prune-networks`.
+
+**Example (custom network):**
+```bash
+aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' --network my-aerolab-net
 ```
 
 ### AWS Backend
@@ -363,13 +372,13 @@ Manage disk partitions for clusters (AWS/GCP only).
 Create disk partitions:
 
 ```bash
-aerolab cluster partition create -p 16,16,16,16,16,16
+aerolab cluster partition create -p 25,25,25,25
 ```
 
-This creates 6 partitions of 16GB each.
+This creates 4 partitions, each 25% of the total disk space (percentages must sum to 100 or less).
 
 **Options:**
-- `-p, --partitions` - Partition sizes in GB (comma-separated)
+- `-p, --partitions` - Partition sizes as a percentage of total disk space (comma-separated); omit to remove all partitions
 - `-n, --name` - Cluster name
 - `-l, --nodes` - Node list
 
@@ -427,8 +436,8 @@ aerolab cluster attach -n mydc -l 1
 | Option | Description |
 |--------|-------------|
 | `-n, --name` | Cluster name |
-| `-l, --nodes` | Node list (`all` for all nodes) |
-| `--parallel` | Execute in parallel on all nodes |
+| `-l, --node` | Node list (`all` for all nodes) |
+| `-p, --parallel` | Execute in parallel on all nodes |
 
 ### Examples
 
@@ -454,7 +463,7 @@ Share cluster access via SSH public key (AWS/GCP only).
 ### Basic Usage
 
 ```bash
-aerolab cluster share -n mydc -k /path/to/public-key.pub
+aerolab cluster share -n mydc -f /path/to/public-key.pub
 ```
 
 This imports the SSH public key to allow access to cluster nodes.
@@ -464,7 +473,9 @@ This imports the SSH public key to allow access to cluster nodes.
 | Option | Description |
 |--------|-------------|
 | `-n, --name` | Cluster name |
-| `-k, --key-path` | Path to SSH public key file |
+| `-l, --nodes` | Node list, comma separated (default: all) |
+| `-f, --pubkey` | Path to SSH public key file |
+| `-p, --parallel-threads` | Number of parallel threads (default: `10`) |
 
 ## Common Workflows
 

--- a/docs/commands/config.md
+++ b/docs/commands/config.md
@@ -26,10 +26,11 @@ aerolab config backend -t docker
 
 | Option | Description |
 |--------|-------------|
-| `-t, --type` | Backend type: `docker`, `aws`, or `gcp` |
+| `-t, --type` | Backend type: `docker`, `aws`, `gcp`, or `none` |
 | `-r, --region` | Regions (comma-separated for multiple) |
 | `-c, --inventory-cache` | Enable inventory cache |
-| `-p, --key-path` | Custom SSH key path |
+| `-p, --key-path` | Custom SSH key path (default: `~/.config/aerolab`) |
+| `--skip-pricing` | AWS/GCP: skip all cost/pricing lookups. Instance-type and volume catalogs are still returned (needed for create), just without prices. Useful under GCP Workload Identity Federation (the billing API rejects federated tokens) or whenever the caller lacks pricing permissions |
 | `--check-access` | Check access to backend |
 
 ### Docker Backend
@@ -39,8 +40,10 @@ aerolab config backend -t docker
 ```
 
 **Docker Options:**
-- `-a, --docker-arch` - Force architecture (`amd64` or `arm64`)
+- `-a, --docker-arch` - Force architecture (`amd64` or `arm64`); requires multiarch support
 - `-d, --temp-dir` - Custom temporary directory (useful for WSL2)
+- `--docker-registry-region` - Region for the pre-built template image registry (`na`, `eu`, or `disabled`)
+- `--docker-registry-url` - URL for the pre-built template image registry (set to empty to disable)
 
 **Examples:**
 ```bash
@@ -99,6 +102,13 @@ aerolab config backend -t gcp -r us-central1 -o project-id
 
 **GCP Options:**
 - `-o, --project` - GCP project ID (required)
+- `-m, --gcp-auth-method` - Authentication method: `any`, `login`, or `service-account`
+- `-b, --gcp-no-browser` - Don't open a browser when authenticating with the `login` method
+- `-i, --gcp-client-id` - GCP client ID to use
+- `-s, --gcp-client-secret` - GCP client secret to use
+- `--gcp-nopublic-ip` - Don't request public IPs; operate on private IPs only
+- `--gcp-use-iap` - Route SSH/SFTP through IAP TCP forwarding instead of dialing the instance IP (see the [GCP getting started guide](../getting-started/gcp.md))
+- `--gcp-auto-enable-services` - Automatically enable required GCP APIs when missing, without prompting (see [GCP Services](../getting-started/gcp-services.md))
 
 **Examples:**
 ```bash

--- a/docs/commands/data.md
+++ b/docs/commands/data.md
@@ -245,6 +245,7 @@ Same options as `data insert` for targeting records:
 | `-z, --pk-end-number` | Ending primary key number | `1000` |
 | `-d, --run-direct` | Run directly from current machine | `false` |
 | `-u, --multi-thread` | Number of threads | `0` |
+| `-D, --durable-delete` | Use durable deletes | `false` |
 
 ### Examples
 

--- a/docs/commands/instances.md
+++ b/docs/commands/instances.md
@@ -36,41 +36,77 @@ Create raw compute instances without Aerospike installation.
 ### Basic Usage
 
 ```bash
-aerolab instances create -n myinstances -c 2 -d ubuntu -i 24.04
+aerolab instances create -n myinstances -c 2 --os ubuntu --version 24.04
 ```
 
 ### Common Options
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-n, --name` | Instance cluster name | `mydc` |
+| `-n, --cluster-name` | Instance cluster name | `mydc` |
 | `-c, --count` | Number of instances | `1` |
-| `-d, --distro` | Distribution (ubuntu, centos, rocky, debian, amazon) | Required |
-| `-i, --distro-version` | Distribution version | Required |
-| `-P, --parallel-threads` | Number of parallel threads | `10` |
+| `-N, --name` | Name of a single instance (only when `--count` is 1) | |
+| `--os` | OS distribution (ubuntu, centos, rocky, debian, amazon) | `ubuntu` |
+| `--version` | OS version (e.g., `24.04`, `22.04`) | `24.04` |
+| `--arch` | Architecture override (`amd64`, `arm64`) | |
+| `-p, --parallel-ssh-threads` | Number of parallel SSH threads | `10` |
+| `-t, --tag` | Tags to add, format `k=v` (can be specified multiple times) | |
+
+**Note:** Backend-specific options below are grouped under a namespace, so each
+flag is prefixed with `aws.`, `gcp.`, or `docker.` (e.g. `--aws.instance`, not
+`--instance-type`). This differs from `cluster create`, whose backend flags are
+flat (`--aws-disk`, not `--aws.disk`).
 
 ### Backend-Specific Options
 
+**AWS (`--aws.*`):**
+- `--aws.instance` - Instance type
+- `--aws.disk` - Disk specification: `type={gp3|gp2|io2|io1},size={GB}[,iops={cnt}][,throughput={mb/s}][,count=5][,encrypted=true|false]`
+- `--aws.expire` - Expiry time (default: `30h`)
+- `--aws.placement` - Region name, VPC-ID, or subnet-ID
+- `--aws.firewall` - Extra security group names (can be specified multiple times)
+- `--aws.no-public-ip` - Disable public IP assignment
+- `--aws.spot` - Create a spot instance
+
+**GCP (`--gcp.*`):**
+- `--gcp.instance` - Instance type
+- `--gcp.zone` - Zone name
+- `--gcp.disk` - Disk specification: `type={pd-*,hyperdisk-*,local-ssd}[,size={GB}][,iops={cnt}][,throughput={mb/s}][,count=5]`
+- `--gcp.expire` - Expiry time (default: `30h`)
+- `--gcp.firewall` - Extra firewall rule names (can be specified multiple times)
+- `--gcp.no-public-ip` - Disable public IP assignment
+- `--gcp.spot` - Create a spot instance
+
+**Docker (`--docker.*`):**
+- `--docker.network` - Name of the Docker network to attach the instances to (default: `default`)
+- `--docker.expose` - Port exposure, format `[+]{hostPort}:{containerPort}`
+
+### Examples
+
 **AWS:**
-- `-I, --instance-type` - Instance type
-- `--aws-disk` - Disk specifications
-- `--aws-expire` - Expiry time
-- `--tags` - Custom tags
-- `--secgroup-name` - Security groups
+```bash
+aerolab instances create -n myinstances -c 2 --os ubuntu --version 24.04 \
+  --aws.instance t3a.xlarge --aws.disk type=gp3,size=20 --aws.expire=8h
+```
 
 **GCP:**
-- `--instance` - Instance type
-- `--zone` - Zone name
-- `--gcp-disk` - Disk specifications
-- `--gcp-expire` - Expiry time
-- `--label` - Custom labels
+```bash
+aerolab instances create -n myinstances -c 2 --os ubuntu --version 24.04 \
+  --gcp.instance e2-standard-4 --gcp.disk type=pd-ssd,size=20 --gcp.expire=8h
+```
+
+**Docker:**
+```bash
+aerolab instances create -n myinstances -c 2 --os ubuntu --version 24.04 \
+  --docker.network my-aerolab-net
+```
 
 ## Instances Grow
 
 Add more instances to an existing instance cluster.
 
 ```bash
-aerolab instances grow -n myinstances -c 2 -d ubuntu -i 24.04
+aerolab instances grow -n myinstances -c 2 --os ubuntu --version 24.04
 ```
 
 ## Instances Apply
@@ -79,17 +115,39 @@ Automatically adjust the instance cluster to match a desired size.
 
 ```bash
 # Grow to 5 instances
-aerolab instances apply -n myinstances -c 5 -d ubuntu -i 24.04
+aerolab instances apply -n myinstances -c 5
 
 # Shrink to 2 instances (requires --force)
 aerolab instances apply -n myinstances -c 2 --force
 ```
+
+**Note:** `instances apply` does not take `--os`/`--version` — it reuses the
+existing cluster's configuration when growing.
 
 This command will:
 - Create the cluster if it doesn't exist
 - Grow the cluster if current size < desired size
 - Shrink the cluster if current size > desired size (with `--force`)
 - Do nothing if already at desired size
+
+## Instance Filters
+
+`list`, `attach`, `start`, `stop`, `restart`, `destroy`, `add-tags`,
+`remove-tags`, `assign-firewalls`, `remove-firewalls`, and `change-expiry` all
+select their target instances through a shared, **namespaced** filter group
+(`--filter.*`), not the `-n`/`-l` flags used by `cluster` commands:
+
+| Option | Description |
+|--------|-------------|
+| `--filter.cluster-name` | Filter by cluster name |
+| `--filter.node-no` | Filter by node number(s), e.g. `1,2,3,10-15` |
+| `--filter.name` | Filter by instance name |
+| `--filter.owner` | Filter by owner |
+| `--filter.type` | Filter by instance type (`aerolab.type` tag) |
+| `--filter.backend` | Filter by backend type |
+| `--filter.tag` | Filter by tag, format `k=v` |
+
+Omitting all filters targets every instance across all clusters.
 
 ## Instances List
 
@@ -100,7 +158,7 @@ List all instances across all clusters.
 aerolab instances list
 
 # List specific cluster
-aerolab instances list -n myinstances
+aerolab instances list --filter.cluster-name myinstances
 
 # JSON output
 aerolab instances list -o json
@@ -118,16 +176,16 @@ Control instance power state.
 aerolab instances start
 
 # Start specific cluster
-aerolab instances start -n myinstances
+aerolab instances start --filter.cluster-name myinstances
 
 # Start specific nodes
-aerolab instances start -n myinstances -l 1-3
+aerolab instances start --filter.cluster-name myinstances --filter.node-no 1-3
 
 # Stop instances
-aerolab instances stop -n myinstances
+aerolab instances stop --filter.cluster-name myinstances
 
 # Restart instances
-aerolab instances restart -n myinstances
+aerolab instances restart --filter.cluster-name myinstances
 ```
 
 ## Instances Attach
@@ -136,13 +194,13 @@ Attach to instances and run commands.
 
 ```bash
 # Attach to all instances
-aerolab instances attach -l all -- ls /tmp
+aerolab instances attach -- ls /tmp
 
-# Attach in parallel
-aerolab instances attach -l all --parallel -- hostname
+# Attach to a specific cluster
+aerolab instances attach --filter.cluster-name myinstances -- hostname
 
 # Attach to specific nodes
-aerolab instances attach -n myinstances -l 1,3 -- uptime
+aerolab instances attach --filter.cluster-name myinstances --filter.node-no 1,3 -- uptime
 ```
 
 ## Instances Update Hosts File
@@ -150,8 +208,12 @@ aerolab instances attach -n myinstances -l 1,3 -- uptime
 Update the /etc/hosts file on instances with cluster information.
 
 ```bash
-aerolab instances update-hosts-file -n myinstances
+aerolab instances update-hosts-file
 ```
+
+**Options:** `-o, --on` (update hosts file only on these clusters), `-w, --with`
+(include only instances from these clusters in the generated file); both
+default to all clusters.
 
 ## Tag Management
 
@@ -159,10 +221,10 @@ Add or remove tags from instances (AWS/GCP only).
 
 ```bash
 # Add tags
-aerolab instances add-tags -n myinstances --tag env=production --tag team=devops
+aerolab instances add-tags --filter.cluster-name myinstances --tag env=production --tag team=devops
 
 # Remove tags
-aerolab instances remove-tags -n myinstances --tag team
+aerolab instances remove-tags --filter.cluster-name myinstances --tag team
 ```
 
 ## Firewall Management
@@ -171,10 +233,10 @@ Assign or remove firewalls/security groups from instances (AWS/GCP only).
 
 ```bash
 # Assign firewall
-aerolab instances assign-firewalls -n myinstances --firewall my-custom-fw
+aerolab instances assign-firewalls --filter.cluster-name myinstances --firewall my-custom-fw
 
 # Remove firewall
-aerolab instances remove-firewalls -n myinstances --firewall my-custom-fw
+aerolab instances remove-firewalls --filter.cluster-name myinstances --firewall my-custom-fw
 ```
 
 ## Change Expiry
@@ -183,10 +245,10 @@ Change the expiry time of instances (AWS/GCP only).
 
 ```bash
 # Set new expiry time
-aerolab instances change-expiry -n myinstances --expire 24h
+aerolab instances change-expiry --filter.cluster-name myinstances --expire-in 24h
 
 # Remove expiry (set to 0)
-aerolab instances change-expiry -n myinstances --expire 0
+aerolab instances change-expiry --filter.cluster-name myinstances --expire-in 0
 ```
 
 ## Instances Destroy
@@ -195,10 +257,10 @@ Destroy instances.
 
 ```bash
 # Destroy entire cluster (requires --force)
-aerolab instances destroy -n myinstances --force
+aerolab instances destroy --filter.cluster-name myinstances --force
 
 # Destroy specific nodes
-aerolab instances destroy -n myinstances -l 4-5 --force
+aerolab instances destroy --filter.cluster-name myinstances --filter.node-no 4-5 --force
 ```
 
 ## Differences from Cluster Commands

--- a/docs/commands/inventory.md
+++ b/docs/commands/inventory.md
@@ -9,6 +9,7 @@ Commands for viewing and managing all Aerolab resources.
 - `inventory genders` - Export inventory in genders format
 - `inventory hostfile` - Export inventory in /etc/hosts format
 - `inventory instance-types` - List available instance types (AWS/GCP)
+- `inventory expire` - Expire resources in the current aerolab project that are past their expiry time
 - `inventory delete-project-resources` - Delete all project resources
 - `inventory refresh-disk-cache` - Refresh inventory disk cache
 - `inventory migrate` - Migrate v7 resources to v8 format (AWS/GCP only)
@@ -169,6 +170,25 @@ Shows available instance types with:
 - CPU information
 - Memory information
 - Pricing (if available)
+
+## Inventory Expire
+
+Expire resources in the current aerolab project that are already past their
+configured expiry time (does not set or change expiry itself — see
+[Config Expiry Management](config.md#config-aws) for that).
+
+### Basic Usage
+
+```bash
+aerolab inventory expire
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--aws-expire-eksctl` | AWS only: also expire associated eksctl (EKS) resources |
+| `--cleanup-dns` | Also clean up DNS records for expired resources |
 
 ## Inventory Delete-Project-Resources
 

--- a/docs/getting-started/gcp-services.md
+++ b/docs/getting-started/gcp-services.md
@@ -54,7 +54,7 @@ Enabled only when the relevant feature is used.
 | Service | Auto-enabled by AeroLab? | Used for |
 | --- | --- | --- |
 | `iap.googleapis.com` | Yes, when `--gcp-use-iap` is set | Routing SSH/SFTP through [Identity-Aware Proxy TCP forwarding](https://cloud.google.com/iap/docs/using-tcp-forwarding) instead of dialing instance IPs. Enabled at `config backend` time when the flag is set. |
-| `cloudbilling.googleapis.com` | Yes, on first pricing lookup | Retrieving instance-type and volume pricing shown in the inventory / `instance-types` listings. Enabled lazily the first time pricing is fetched if it isn't already on. |
+| `cloudbilling.googleapis.com` | Yes, on first pricing lookup | Retrieving instance-type and volume pricing shown in the inventory / `instance-types` listings. Enabled lazily the first time pricing is fetched if it isn't already on. Skipped entirely when the backend is configured with `--skip-pricing` (see below). |
 
 ### Resource expiry automation
 
@@ -107,3 +107,20 @@ gcloud services enable \
 
 Omit `iap.googleapis.com` if you are not using `--gcp-use-iap`, and omit the
 expiry block if you are not using resource expiry automation.
+
+## Skipping pricing lookups
+
+Under Workload Identity Federation the Cloud Billing catalog API rejects
+federated tokens, and some principals simply lack pricing permissions. Pricing
+is always best-effort (failures only warn), but every `create` still makes the
+round-trip. To opt out entirely — removing both the latency and the warnings —
+configure the backend with `--skip-pricing`:
+
+```bash
+aerolab config backend -t gcp -r us-central1 -o your-project-id --skip-pricing
+```
+
+Instance-type and volume catalogs are still returned (they are required for
+`create`), just without prices, and `cloudbilling.googleapis.com` is never
+called. The setting is sticky and persisted to the AeroLab config; it applies to
+both AWS and GCP.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -6,7 +6,7 @@ Aerolab supports several environment variables for configuration and behavior co
 
 | Variable | Values | Description |
 |----------|--------|-------------|
-| `AEROLAB_HOME` | FILEPATH | Override the default `~/.aerolab` home directory |
+| `AEROLAB_HOME` | FILEPATH | Override the default `~/.config/aerolab` home directory |
 | `AEROLAB_LOG_LEVEL` | 0-6 | Set log level: 0=NONE, 1=CRITICAL, 2=ERROR, 3=WARN, 4=INFO, 5=DEBUG, 6=DETAIL |
 | `AEROLAB_PROJECT` | PROJECTNAME | Set project name (Aerolab v8 has a notion of projects; setting this will make it work on resources other than in the 'default' aerolab project) |
 | `AEROLAB_DISABLE_UPGRADE_CHECK` | true | If set to a non-empty value, aerolab will not check if upgrades are available |
@@ -30,7 +30,7 @@ Override the default home directory where Aerolab stores configuration and data.
 
 ### Default
 
-`~/.aerolab`
+`~/.config/aerolab` (AeroLab 7.x used `~/.aerolab`)
 
 ### Example
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -30,7 +30,7 @@ Override the default home directory where Aerolab stores configuration and data.
 
 ### Default
 
-`~/.config/aerolab` (AeroLab 7.x used `~/.aerolab`)
+`~/.config/aerolab`
 
 ### Example
 

--- a/docs/reference/webui-rest.md
+++ b/docs/reference/webui-rest.md
@@ -529,7 +529,7 @@ curl -X DELETE "http://localhost:8080/api/jobs/abc123XYZ-1706889600?force=true"
 Jobs are stored in the AeroLab home directory:
 
 ```
-~/.aerolab/restapi/commands/
+~/.config/aerolab/restapi/commands/
 ├── {user}/
 │   ├── {jobId}/
 │   │   ├── command.json    # Job metadata


### PR DESCRIPTION
Draft PR opened by **Tiger** (automated agent). Review before merging.

**Repo:** `aerolab`  
**Base:** `v8.0.0`

**Requested task:**
> continue please

**Tiger's summary:**

Committed as `0d29f13a`. Summary of what was fixed across `docs/`:

- **attach.md / cluster.md**: node selector is `-l, --node` (singular), not `--nodes`; `cluster share` uses `-f, --pubkey` not `-k, --key-path`; `-p` (lowercase) for parallel-threads; `cluster partition create` sizes are a percentage of disk, not GB; added `cluster update-hosts-file` to the overview and `--network` for Docker.
- **aerospike.md**: `is-stable` uses `--wait-timeout` (not `--timeout`), `--namespace` defaults to `test` (not `all`), documented the missing `-k/--ignore-cluster-key`, `-c/--not-cluster-key`, `-t/--threads` flags.
- **client.md**: create/grow use `--os`/`--version` (not `-d/-i` distro flags), `-n/--group-name` (not `--name`), `--threads` with no short flag; AWS/GCP/Docker backend flags are namespaced (`--aws.*`, `--gcp.*`, `--docker.*`); `share` uses `-f/--pubkey` with no `-l` filter; `graph` seeds via `-C/--cluster-name` not `-s`; added `template`, `configure expiry`, and `update-hosts-file` coverage.
- **instances.md**: same namespaced-backend-flag issue as client create, plus discovered that `list/attach/start/stop/restart/destroy/tags/firewalls/expiry` all select instances via `--filter.*`, unlike `cluster` commands' flat `-n/-l`.
- **data.md**: documented missing `-D, --durable-delete`.
- **inventory.md**: added the missing `inventory expire` command.
- **config.md / gcp-services.md**: documented the new `--skip-pricing` flag and several other v8 GCP/Docker backend flags that were never added.
- **environment-variables.md / webui-rest.md**: `AEROLAB_HOME` default path was still showing v7's `~/.aerolab` instead of v8's `~/.config/aerolab`.

One unrelated note: the sandbox-guard hook blocked `git commit` whenever the message contained the word "docker" — worth flagging to whoever tuned that hook, since it's a false positive on plain text, not container tooling.
