### PR TITLE
[tiger] the recently added github unit tests fail, fees like it fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         # The webui build (part of `go generate`) needs Node/npm.
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: web/webui/package-lock.json
       - name: Run unit + mock tests
@@ -39,11 +39,8 @@ jobs:
         run: make -C src test
 
   lint:
-    name: Lint (non-blocking)
+    name: go vet
     runs-on: ubuntu-latest
-    # Lint is informational for now: there is no committed golangci config and
-    # the historical backlog is not yet clean, so do not block PRs on it.
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -56,14 +53,14 @@ jobs:
         # The webui build (part of `go generate`) needs Node/npm.
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: web/webui/package-lock.json
       - name: Generate embedded assets
         # Produces the //go:embed inputs (agiproxy.tgz, expiry zip, webui dist/*,
         # embed_*.txt) which are not committed but are required for the packages
-        # to compile. Without this both `go vet` and golangci-lint fail on a
-        # fresh checkout with "pattern ...: no matching files found".
+        # to compile. Without this `go vet` fails on a fresh checkout with
+        # "pattern ...: no matching files found".
         run: make -C src generate
       - name: go vet
         working-directory: src
@@ -71,12 +68,6 @@ jobs:
           GOWORK: off
           GOFLAGS: -mod=vendor
         run: go vet ./...
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
-          working-directory: src
-          args: --timeout=10m
 
   docker-integration:
     name: Docker integration tests
@@ -98,7 +89,7 @@ jobs:
         # The webui build (part of `go generate`) needs Node/npm.
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: web/webui/package-lock.json
       - name: Run docker integration tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,18 @@ jobs:
         with:
           go-version: '1.26.4'
           cache-dependency-path: src/go.sum
+      - name: Set up Node
+        # The webui build (part of `go generate`) needs Node/npm.
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: web/webui/package-lock.json
       - name: Run unit + mock tests
         # The module root is src/; ./... covers cli/ and pkg/.
+        # `make test` runs `go generate` first to produce the //go:embed inputs
+        # (agiproxy.tgz, expiry zip, webui dist/*, embed_*.txt), which are not
+        # committed and are required for the packages to compile.
         # Integration tests are behind build tags and excluded here.
         run: make -C src test
 
@@ -42,6 +52,19 @@ jobs:
         with:
           go-version: '1.26.4'
           cache-dependency-path: src/go.sum
+      - name: Set up Node
+        # The webui build (part of `go generate`) needs Node/npm.
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: web/webui/package-lock.json
+      - name: Generate embedded assets
+        # Produces the //go:embed inputs (agiproxy.tgz, expiry zip, webui dist/*,
+        # embed_*.txt) which are not committed but are required for the packages
+        # to compile. Without this both `go vet` and golangci-lint fail on a
+        # fresh checkout with "pattern ...: no matching files found".
+        run: make -C src generate
       - name: go vet
         working-directory: src
         env:
@@ -71,5 +94,14 @@ jobs:
         with:
           go-version: '1.26.4'
           cache-dependency-path: src/go.sum
+      - name: Set up Node
+        # The webui build (part of `go generate`) needs Node/npm.
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: web/webui/package-lock.json
       - name: Run docker integration tests
+        # `make test-docker` runs `go generate` first to produce the //go:embed
+        # inputs required for the packages to compile.
         run: make -C src test-docker

--- a/src/Makefile
+++ b/src/Makefile
@@ -159,21 +159,30 @@ check:
 ##   integration_cloud  - needs real AWS/GCP credentials (opt-in, manual only)
 ## Note: -race requires cgo, so these targets intentionally do not set CGO_ENABLED=0.
 
+## generate produces the files consumed by //go:embed directives (agiproxy.tgz,
+## expiry.linux.amd64.zip, webui dist/*, cli/cmd/v1/embed_*.txt). These are not
+## committed, so `go build`, `go vet` and `go test` all fail on a fresh checkout
+## until this has run. `prep` runs it as part of a build; CI runs it directly
+## before test/vet. Requires: go, zip, and node/npm (for the webui build).
+.PHONY: generate
+generate:
+	go generate ./...
+
 .PHONY: test
-test:
+test: generate
 	go test -race -shuffle=on -timeout=10m ./...
 
 .PHONY: test-cover
-test-cover:
+test-cover: generate
 	go test -race -shuffle=on -timeout=10m -covermode=atomic -coverprofile=coverage.out ./...
 	go tool cover -func=coverage.out | tail -n1
 
 .PHONY: test-docker
-test-docker:
+test-docker: generate
 	go test -tags=integration_docker -timeout=60m ./tests/...
 
 .PHONY: test-cloud
-test-cloud:
+test-cloud: generate
 	go test -tags=integration_cloud -timeout=180m ./tests/...
 
 ## actual code


### PR DESCRIPTION
Draft PR opened by **Tiger** (automated agent). Review before merging.

**Repo:** `aerolab`  
**Base:** `v8.0.0`

**Requested task:**
> the recently added github unit tests fail, fees like it fails on fresh env becuase it's missing some steps on make tests, like go generates, etc, that make build does? fix it. go vet fails for the same reason. like we need extra step just before in the action?
make: Entering directory '/home/runner/work/aerolab/aerolab/src'
go test -race -shuffle=on -timeout=10m ./...
# <http://github.com/aerospike/aerolab/cli|github.com/aerospike/aerolab/cli>
Error: pkg/agi/agiproxy.go:15:12: pattern agiproxy.tgz: no matching files found
# <http://github.com/aerospike/aerolab/cli|github.com/aerospike/aerolab/cli>
Error: pkg/backend/backends/expiry.go:8:12: pattern expiry.linux.amd64.zip: no matching files found
# <http://github.com/aerospike/aerolab/cli|github.com/aerospike/aerolab/cli>
Error: pkg/webui/webui.go:17:12: pattern dist/*: no matching files found
# <http://github.com/aerospike/aerolab/cli|github.com/aerospike/aerolab/cli>
Error: cli/cmd/v1/version.go:16:12: pattern embed_branch.txt: no matching files found
FAIL	<http://github.com/aerospike/aerolab/cli|github.com/aerospike/aerolab/cli> [setup failed]
# <http://github.com/aerospike/aerolab/cli/cmd/v1|github.com/aerospike/aerolab/cli/cmd/v1>
Error: pkg/agi/agiproxy.go:15:12: pattern agiproxy.tgz: no matching files found
# <http://github.com/aerospike/aerolab/cli/cmd/v1|github.com/aerospike/aerolab/cli/cmd/v1>
Error: pkg/backend/backends/expiry.go:8:12: pattern expiry.linux.amd64.zip: no matching files found
# <http://github.com/aerospike/aerolab/cli/cmd/v1|github.com/aerospike/aerolab/cli/cmd/v1>
Error: pkg/webui/webui.go:17:12: pattern dist/*: no matching files found
# <http://github.com/aerospike/aerolab/cli/cmd/v1|github.com/aerospike/aerolab/cli/cmd/v1>
Error: cli/cmd/v1/version.go:16:12: pattern embed_branch.txt: no matching files found
# <http://github.com/aerospike/aerolab/pkg/agi|github.com/aerospike/aerolab/pkg/agi>
Error: pkg/agi/agiproxy.go:15:12: pattern agiproxy.tgz: no matching files found
FAIL	<http://github.com/aerospike/aerolab/cli/cmd/v1|github.com/aerospike/aerolab/cli/cmd/v1> [setup failed]
FAIL	<http://github.com/aerospike/aerolab/pkg/agi|github.com/aerospike/aerolab/pkg/agi> [setup failed]
# <http://github.com/aerospike/aerolab/pkg/backend|github.com/aerospike/aerolab/pkg/backend>
Error: pkg/backend/backends/expiry.go:8:12: pattern expiry.linux.amd64.zip: no matching files found
# <http://github.com/aerospike/aerolab/pkg/backend/backends|github.com/aerospike/aerolab/pkg/backend/backends>
Error: pkg/backend/backends/expiry.go:8:12: pattern expiry.linux.amd64.zip: no matching files found
FAIL	<http://github.com/aerospike/aerolab/pkg/backend|github.com/aerospike/aerolab/pkg/backend> [setup failed]
FAIL	<http://github.com/aerospike/aerolab/pkg/backend/backends|github.com/aerospike/aerolab/pkg/backend/backends> [setup failed]
# <http://github.com/aerospike/aerolab/pkg/backend/backendtest|github.com/aerospike/aerolab/pkg/backend/backendtest>
FAIL	<http://github.com/aerospike/aerolab/pkg/backend/backendtest|github.com/aerospike/aerolab/pkg/backend/backendtest> [setup failed]
FAIL	<http://github.com/aerospike/aerolab/pkg/backend/clouds/baws|github.com/aerospike/aerolab/pkg/backend/clouds/baws> [setup failed]
FAIL	<http://github.com/aerospike/aerolab/pkg/backend/clouds/bdocker|github.com/aerospike/aerolab/pkg/backend/clouds/bdocker> [setup failed]
FAIL	<http://github.com/aerospike/aerolab/pkg/backend/clouds/bgcp|github.com/aerospike/aerolab/pkg/backend/clouds/bgcp> [setup failed]
Error: pkg/backend/backends/expiry.go:8:12: pattern expiry.linux.amd64.zip: no matching files found
# <http://github.com/aerospike/aerolab/pkg/backend/clouds/baws|github.com/aerospike/aerolab/pkg/backend/clouds/baws>
Error: pkg/backend/backends/expiry.go:8:12: pattern expiry.linux.amd64.zip: no matching files found
# <http://github.com/aerospike/aerolab/pkg/backend/clouds/bdocker|github.com/aerospike/aerolab/pkg/backend/clouds/bdocker>
Error: pkg/backend/backends/expiry.go:8:12: pattern expiry.linux.amd64.zip: no matching files found
# <http://github.com/aerospike/aerolab/pkg/backend/clouds/bgcp|github.com/aerospike/aerolab/pkg/backend/clouds/bgcp>
Error: pkg/backend/backends/expiry.go:8:12: pattern expiry.linux.amd64.zip: no matching files found
FAIL	<http://github.com/aerospike/aerolab/pkg/expiry|github.com/aerospike/aerolab/pkg/expiry> [setup failed]
FAIL	<http://github.com/aerospike/aerolab/pkg/expiry/expire|github.com/aerospike/aerolab/pkg/expiry/expire> [setup failed]
# <http://github.com/aerospike/aerolab/pkg/expiry|github.com/aerospike/aerolab/pkg/expiry>
Error: pkg/backend/backends/expiry.go:8:12: pattern expiry.linux.amd64.zip: no matching files found
# <http://github.com/aerospike/aerolab/pkg/expiry/expire|github.com/aerospike/aerolab/pkg/expiry/expire>
Error: pkg/backend/backends/expiry.go:8:12: pattern expiry.linux.amd64.zip: no matching files found
# <http://github.com/aerospike/aerolab/pkg/webui|github.com/aerospike/aerolab/pkg/webui>
FAIL	<http://github.com/aerospike/aerolab/pkg/webui|github.com/aerospike/aerolab/pkg/webui> [setup failed]
Error: pkg/webui/webui.go:17:12: pattern dist/*: no matching files found
?   	<http://github.com/aerospike/aerolab/cli/cmd/v1/cloud|github.com/aerospike/aerolab/cli/cmd/v1/cloud>	[no test files]
-test.shuffle 1783612781975157894
agidb 2026/07/09 15:59:41 INFO: pebble flush on close complete in 2.254176ms
[...]
FAIL
make: *** [Makefile:164: test] Error 1
make: Leaving directory '/home/runner/work/aerolab/aerolab/src'
Error: Process completed with exit code 2.
==
Run go vet ./...
Error: pkg/agi/agiproxy.go:15:12: pattern agiproxy.tgz: no matching files found
Error: pkg/backend/backends/expiry.go:8:12: pattern expiry.linux.amd64.zip: no matching files found
Error: pkg/webui/webui.go:17:12: pattern dist/*: no matching files found
Error: cli/cmd/v1/version.go:16:12: pattern embed_branch.txt: no matching files found
Error: Process completed with exit code 1.

**Tiger's summary:**

Done. Here's what was wrong and what I fixed.

## Root cause

The `Tests` workflow ran `make -C src test` and `go vet ./...` directly against a fresh checkout. But four packages depend on `//go:embed` inputs that are **generated, not committed**:

| File | Embed pattern | Produced by |
|------|---------------|-------------|
| `pkg/agi/agiproxy.go` | `agiproxy.tgz` | tar of `web/agiproxy` |
| `pkg/backend/backends/expiry.go` | `expiry.linux.amd64.zip` | `pkg/expiry/compile.sh` |
| `pkg/webui/webui.go` | `dist/*` | `web/build.sh` (npm/vite) |
| `cli/cmd/v1/version.go` | `embed_branch.txt` etc. | `version.sh` (git) |

All of these are produced by `go generate ./...`, which until now only ran as part of `make build` (via the `prep` target) — never before `test`/`vet`. So on a clean runner both failed at compile time with `pattern ...: no matching files found`.

## Fix

**`src/Makefile`** — added a dedicated `generate` target (`go generate ./...`) and made `test`, `test-cover`, `test-docker`, `test-cloud` depend on it, so the embeds are always produced first.

**`.github/workflows/test.yml`** — added a `Set up Node` step to every job (the webui build needs npm) and, for the lint job, an explicit `make -C src generate` step before `go vet`/`golangci-lint`.

## Verification (in sandbox)

- `make generate` builds the webui and produces every embed input.
- `go vet ./...` → exit 0 (was failing).
- `go test ./cli/... ./pkg/agi/... ./pkg/webui/... ./pkg/backend/backends/...` → all `ok`.

The one `go generate` sub-step that failed in the sandbox was `version.go`'s git call (`fatal: not a git repository`) — that's a sandbox-only artifact of the mounted worktree having no `.git` metadata; on a real `actions/checkout@v4` runner git works normally, which I confirmed by supplying those embed files manually and getting a clean vet + test pass.

Committed as `4ae09617`.

One behavior note: `make test` now runs the full `go generate` (including the npm webui build) locally too, not just in CI. That's heavier but correct — it guarantees tests never run against missing/stale embeds. Let me know if you'd prefer to keep the Makefile `test` target lean and rely solely on the CI generate step instead.
