### PR TITLE
[tiger] Can the aerolab v7 run any gpu instance? I gte the following

### DIFF
--- a/src/backendGcp.go
+++ b/src/backendGcp.go
@@ -3744,7 +3744,9 @@ func (d *backendGcp) DeployCluster(v backendVersion, name string, nodeCount int,
 		}
 
 		op, err := instancesClient.Insert(ctx, req)
-		if err != nil && (strings.Contains(err.Error(), "OnHostMaintenance must be set to TERMINATE") || strings.Contains(err.Error(), "not support live migration")) {
+		if err != nil && onHostMaintenance != "TERMINATE" && (strings.Contains(err.Error(), "OnHostMaintenance must be set to TERMINATE") ||
+			strings.Contains(err.Error(), "not support live migration") ||
+			(strings.Contains(err.Error(), "onHostMaintenance") && strings.Contains(err.Error(), "TERMINATE"))) {
 			req.InstanceResource.Scheduling.OnHostMaintenance = proto.String("TERMINATE")
 			onHostMaintenance = "TERMINATE"
 			log.Print("OnHostMaintenance mode not supported, attempting to switch to TERMINATE")


### PR DESCRIPTION
Draft PR opened by **Tiger** (automated agent). Review before merging.

**Repo:** `aerolab`  
**Base:** `master`

**Requested task:**
> Can the aerolab v7 run any gpu instance? I gte the following:
```$ aerolab cluster create --name 'test-v1' --instance 'a3-highgpu-1g' --owner 'lucien' --firewall lucien

2026/07/08 20:32:23 +0000 Running cluster.create
2026/07/08 20:32:23 +0000 Pre-tax cost for 1 a3-highgpu-1g instances (does not include disk or network costs): $ 1.1825/hour ; $ 28.38/day ; $ 865.60/month

2026/07/08 20:32:24 +0000 Checking if template exists
2026/07/08 20:32:25 +0000 Distro = ubuntu:24.04 ; AerospikeVersion = 8.1.2.3
2026/07/08 20:32:25 +0000 Features file: /opt/features/features.conf.v2
2026/07/08 20:32:25 +0000 Starting deployment
2026/07/08 20:32:27 +0000 Expiries: checking if job exists already
2026/07/08 20:32:28 +0000 Expiries: done
2026/07/08 20:32:28 +0000 unable to create instance: googleapi: Error 400: Invalid value for field 'resource.scheduling.onHostMaintenance': 'MIGRATE'. Scheduling must have onHostMaintenance be one of the following valid types: [TERMINATE]. But was MIGRATE

-&gt;Refreshing interface data

-&gt;Refresh finished

-=-=-=-=- [ExitCode] 1 -=-=-=-=-
exit status 1
-=-=-=-=- [END] -=-=-=-=-```

**Tiger's summary:**

## Answer

Yes — aerolab already supports GPU instance types on GCP (there's GPU-aware pricing logic for A2/A3 families, and a dedicated `Scheduling.OnHostMaintenance` field). Your failure is a known GCP constraint, not a missing feature: **any instance with GPUs attached must use `onHostMaintenance: TERMINATE`, not `MIGRATE`**, because GCP can't live-migrate a VM with attached accelerators.

aerolab already has fallback logic for exactly this — if instance creation fails, it retries once with `TERMINATE` (`backendGcp.go:3747`). The bug is that the retry only fires on two hardcoded substrings in the error message, and neither matched the error your GCP project returned:

```
Invalid value for field 'resource.scheduling.onHostMaintenance': 'MIGRATE'.
Scheduling must have onHostMaintenance be one of the following valid types: [TERMINATE]. But was MIGRATE
```

So the retry silently never kicked in and the deploy just failed.

**Fix committed** (`2e4e5c5d`): broadened the detection to also match any error mentioning both `onHostMaintenance` and `TERMINATE`, covering this phrasing (and likely other GCP API variants) in addition to the two originally-handled messages. Verified it builds and vets clean.

**Immediate workaround** if you don't want to wait for this to land: pass `--on-host-maintenance-policy TERMINATE` explicitly on your `cluster create` command — that flag already existed and bypasses the retry logic entirely.
