### PR TITLE
[tiger] The below is from v7 aerolab, does v8 have the same issue? i

### DIFF
--- a/src/cli/cmd/v1/cmdClusterCreate.go
+++ b/src/cli/cmd/v1/cmdClusterCreate.go
@@ -95,7 +95,7 @@ type ClusterCreateCmdGcp struct {
 	VolLabels           []string        `long:"gcp-vol-label" description:"apply custom labels to volume; format: key=value; this parameter can be specified multiple times" simplemode:"false"`
 	VolSize             int             `long:"gcp-vol-size" description:"set volume size in GB" simplemode:"false"`
 	TerminateOnPoweroff bool            `long:"gcp-terminate-on-poweroff" description:"if set, when shutdown or poweroff is executed from the instance itself, it will be stopped AND terminated" simplemode:"false"`
-	OnHostMaintenance   string          `long:"on-host-maintenance-policy" description:"on-host maintenance policy: MIGRATE or TERMINATE; defaults to MIGRATE (or TERMINATE for spot)" simplemode:"false"`
+	OnHostMaintenance   string          `long:"on-host-maintenance-policy" description:"on-host maintenance policy: MIGRATE or TERMINATE; defaults to MIGRATE (or TERMINATE for spot and GPU instance types, e.g. A2/A3/A4/G2)" simplemode:"false"`
 	MinCPUPlatform      string          `long:"gcp-min-cpu-platform" description:"set the minimum CPU platform; see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform"`
 	GVNIC               bool            `long:"gcp-gvnic" description:"use Google Virtual NIC (gVNIC) instead of the default VirtIO NIC; required for highest network performance and for some newer instance types"`
 	IAMInstanceProfile  string          `long:"gcp-instance-profile" description:"IAM instance profile to use for the instances"`

--- a/src/cli/cmd/v1/cmdInstancesCreate.go
+++ b/src/cli/cmd/v1/cmdInstancesCreate.go
@@ -109,7 +109,7 @@ type InstancesCreateCmdGcp struct {
 	IAMInstanceProfile string          `long:"instance-profile" description:"IAM instance profile to use for the instances"`
 	MinCPUPlatform     string          `long:"min-cpu-platform" description:"Minimum CPU platform to use for the instances"`
 	GVNIC              bool            `long:"gvnic" description:"Use Google Virtual NIC (gVNIC) instead of the default VirtIO NIC; required for highest network performance and for some newer instance types"`
-	OnHostMaintenance  string          `long:"on-host-maintenance" description:"On-host maintenance policy: MIGRATE or TERMINATE; defaults to MIGRATE (or TERMINATE for spot)"`
+	OnHostMaintenance  string          `long:"on-host-maintenance" description:"On-host maintenance policy: MIGRATE or TERMINATE; defaults to MIGRATE (or TERMINATE for spot and GPU instance types, e.g. A2/A3/A4/G2)"`
 	CustomDNS          InstanceDNS     `group:"Automated Custom GCP DNS" namespace:"dns" description:"backend-gcp"`
 }
 

--- a/src/pkg/backend/clouds/bgcp/instances.go
+++ b/src/pkg/backend/clouds/bgcp/instances.go
@@ -74,7 +74,8 @@ type CreateInstanceParams struct {
 	// optional: if specified, and Image==nil, will lookup this image ID and use it (for custom images)
 	// format: projects/<project>/global/images/<image>
 	CustomImageID string `yaml:"customImageID" json:"customImageID"`
-	// optional: the on-host maintenance policy for the instance(node); if not set, will default to MIGRATE (or TERMINATE for spot)
+	// optional: the on-host maintenance policy for the instance(node); if not set, will default to MIGRATE
+	// (or TERMINATE for spot instances and GPU machine types, e.g. A2/A3/A4/G2, which do not support live migration)
 	// valid values: MIGRATE, TERMINATE
 	OnHostMaintenance string `yaml:"onHostMaintenance" json:"onHostMaintenance"`
 	// optional: if true, the instance(node) will use Google Virtual NIC (gVNIC) instead of the default VirtIO NIC
@@ -137,6 +138,22 @@ func fetchLabelFingerprint(ctx context.Context, client *compute.InstancesClient,
 		return "", nil, err
 	}
 	return inst.GetLabelFingerprint(), inst.GetLabels(), nil
+}
+
+// gpuMachineFamilyPrefixes lists GCP machine type families that have GPUs
+// built in and therefore do not support live migration; GCP requires these
+// to use onHostMaintenance=TERMINATE.
+var gpuMachineFamilyPrefixes = []string{"a2-", "a3-", "a4-", "g2-"}
+
+// isGpuMachineType returns true if the given machine type belongs to a GPU
+// machine family (e.g. a2-highgpu-1g, a3-highgpu-8g, g2-standard-4).
+func isGpuMachineType(instanceType string) bool {
+	for _, prefix := range gpuMachineFamilyPrefixes {
+		if strings.HasPrefix(instanceType, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func getArchitecture(instance *computepb.Instance) backends.Architecture {
@@ -1753,6 +1770,10 @@ func (s *b) CreateInstances(input *backends.CreateInstanceInput, waitDur time.Du
 	case backendSpecificParams.OnHostMaintenance != "":
 		onHostMaintenance = backendSpecificParams.OnHostMaintenance
 	case backendSpecificParams.SpotInstance:
+		onHostMaintenance = "TERMINATE"
+	case isGpuMachineType(backendSpecificParams.InstanceType):
+		// GPU-attached machine families (A2, A3, A4, G2) do not support live
+		// migration; GCP rejects onHostMaintenance=MIGRATE for these.
 		onHostMaintenance = "TERMINATE"
 	default:
 		onHostMaintenance = "MIGRATE"

--- a/src/pkg/backend/clouds/bgcp/pure_test.go
+++ b/src/pkg/backend/clouds/bgcp/pure_test.go
@@ -158,6 +158,21 @@ func TestUnsanitizeHelpers(t *testing.T) {
 	}
 }
 
+func TestIsGpuMachineType(t *testing.T) {
+	gpu := []string{"a2-highgpu-1g", "a2-megagpu-16g", "a3-highgpu-8g", "a3-megagpu-8g", "a4-highgpu-8g", "g2-standard-4"}
+	for _, in := range gpu {
+		if !isGpuMachineType(in) {
+			t.Errorf("isGpuMachineType(%q) = false, want true", in)
+		}
+	}
+	notGpu := []string{"n1-standard-1", "e2-medium", "c3-standard-4", "t2a-standard-1", ""}
+	for _, in := range notGpu {
+		if isGpuMachineType(in) {
+			t.Errorf("isGpuMachineType(%q) = true, want false", in)
+		}
+	}
+}
+
 func TestNormalizeAerospikeVersionGCP(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"", ""},


### PR DESCRIPTION
Draft PR opened by **Tiger** (automated agent). Review before merging.

**Repo:** `aerolab`  
**Base:** `v8.0.0`

**Requested task:**
> The below is from v7 aerolab, does v8 have the same issue? if so, fix it, it's for the GPU instances specifically that they cannot have onHostMaintenance MIGRATE for those
```$ aerolab cluster create --name 'test-v1' --instance 'a3-highgpu-1g' --owner 'lucien' --firewall lucien

2026/07/08 20:32:23 +0000 Running cluster.create
2026/07/08 20:32:23 +0000 Pre-tax cost for 1 a3-highgpu-1g instances (does not include disk or network costs): $ 1.1825/hour ; $ 28.38/day ; $ 865.60/month

2026/07/08 20:32:24 +0000 Checking if template exists
2026/07/08 20:32:25 +0000 Distro = ubuntu:24.04 ; AerospikeVersion = 8.1.2.3
2026/07/08 20:32:25 +0000 Features file: /opt/features/features.conf.v2
2026/07/08 20:32:25 +0000 Starting deployment
2026/07/08 20:32:27 +0000 Expiries: checking if job exists already
2026/07/08 20:32:28 +0000 Expiries: done
2026/07/08 20:32:28 +0000 unable to create instance: googleapi: Error 400: Invalid value for field 'resource.scheduling.onHostMaintenance': 'MIGRATE'. Scheduling must have onHostMaintenance be one of the following valid types: [TERMINATE]. But was MIGRATE```

**Tiger's summary:**

Confirmed clean — the sandbox's embed stubs were isolated to its own copy and never touched the real worktree.

## Summary

Yes, v8 had the same bug. In `src/pkg/backend/clouds/bgcp/instances.go`, `CreateInstances` defaulted `onHostMaintenance` to `MIGRATE` unless the instance was spot or the user explicitly overrode it — with no exception for GPU machine types. GCP rejects `MIGRATE` for GPU-attached families (A2, A3, A4, G2) since they can't be live-migrated, which is exactly the 400 error in the log for `a3-highgpu-1g`.

Fix: added `isGpuMachineType()` (prefix match on `a2-`/`a3-`/`a4-`/`g2-`) and made it default those instance types to `TERMINATE`, same precedence as the existing spot-instance handling. Explicit `--on-host-maintenance` / `--on-host-maintenance-policy` flags still take priority. Updated flag/field docs to mention the new default, added a unit test (`TestIsGpuMachineType`), and verified `go build ./...` and the `pkg/backend/...` test suite pass. Committed as `f36edc98`.
