### PR TITLE
[tiger] make sure the getting started is not convoluted, is simple a

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,7 @@
 # AeroLab
 
-AeroLab is a tool for deploying and managing Aerospike clusters across multiple cloud providers and Docker.
-
-## Documentation
-
-- [Getting Started](docs/getting-started/README.md)
-- [Commands Reference](docs/commands/)
-- [Cloud Configuration](docs/cloud/)
-- [MCP Server for AI agents](docs/mcp.md) - Drive AeroLab from Claude, Cursor, Codex, etc. via `aerolab mcp`
-- [Migration Guide](docs/migration-guide.md) - Upgrading from AeroLab 7.x to 8.x
+AeroLab deploys and manages Aerospike clusters on Docker, AWS, or GCP — for local dev,
+testing, and performance benchmarking.
 
 ## Quick Start
 
@@ -25,6 +18,17 @@ aerolab cluster create -n mycluster -c 3
 # List clusters
 aerolab cluster list
 ```
+
+Want AWS or GCP instead of Docker? Both need extra setup (credentials, and gotchas like
+private-only VPCs) — see [Getting Started](docs/getting-started/README.md).
+
+## Documentation
+
+- [Getting Started](docs/getting-started/README.md) - install, configure a backend, create your first cluster
+- [Commands Reference](docs/commands/)
+- [Cloud Configuration](docs/cloud/)
+- [MCP Server for AI agents](docs/mcp.md) - Drive AeroLab from Claude, Cursor, Codex, etc. via `aerolab mcp`
+- [Migration Guide](docs/migration-guide.md) - Upgrading from AeroLab 7.x to 8.x
 
 ## Migration from v7.x
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -169,68 +169,11 @@ If you're upgrading from AeroLab v7.x, see the **[Migration Guide](migration-gui
 
 ## Quick Start Example
 
-### Docker Backend
-
-```bash
-# Configure Docker backend
-aerolab config backend -t docker
-
-# Create a 2-node cluster
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*'
-
-# Check cluster status
-aerolab cluster list
-
-# Start Aerospike
-aerolab aerospike start
-
-# Check if cluster is stable
-aerolab aerospike is-stable -w
-
-# View cluster status
-aerolab aerospike status
-```
-
-### AWS Backend
-
-```bash
-# Configure AWS backend (requires AWS credentials in ~/.aws/credentials)
-aerolab config backend -t aws -r us-east-1
-
-# Create a 2-node cluster with expiry
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  -I t3a.xlarge \
-  --aws-disk type=gp3,size=20 \
-  --aws-expire=8h
-
-# Start cluster
-aerolab cluster start
-
-# Start Aerospike
-aerolab aerospike start
-```
-
-### GCP Backend
-
-```bash
-# Authenticate with GCP first (required)
-gcloud auth application-default login
-
-# Configure GCP backend
-aerolab config backend -t gcp -r us-central1 -o your-project-id
-
-# Create a 2-node cluster with expiry
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  --instance e2-standard-4 \
-  --gcp-disk type=pd-ssd,size=20 \
-  --gcp-expire=8h
-
-# Start cluster
-aerolab cluster start
-
-# Start Aerospike
-aerolab aerospike start
-```
+Pick a backend and follow its guide for prerequisites, gotchas (private-only VPCs, GCP IAP,
+etc.), and a working quick start: [Docker](getting-started/docker.md),
+[AWS](getting-started/aws.md), [GCP](getting-started/gcp.md). Everything after
+`cluster create` — starting/stopping, attach, files, cleanup — is the same on every backend:
+see [Common Operations](getting-started/common-operations.md).
 
 ## Common Workflows
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -100,7 +100,9 @@ Deploy Aerospike clusters on AWS EC2 instances. Ideal for production-like testin
 aerolab config backend -t aws -r us-east-1
 ```
 
-Running in a private-only VPC? Add `--aws-nopublic-ip` to skip public IP assignment — see [Disable Public IPs](aws.md#optional-disable-public-ips).
+**Gotcha:** running in a private-only VPC? `--aws-nopublic-ip` stops Aerolab requesting a
+public IP, but there's no AWS equivalent of GCP's IAP tunnel — you need your own VPN,
+peering, or bastion access to reach the instances. See [Disable Public IPs](aws.md#optional-disable-public-ips).
 
 → **[AWS Getting Started Guide](aws.md)**
 
@@ -112,7 +114,10 @@ Deploy Aerospike clusters on Google Cloud Compute Engine. Ideal for production-l
 aerolab config backend -t gcp -r us-central1 -o your-project-id
 ```
 
-Running in a private-only VPC? Add `--gcp-nopublic-ip` to skip public IP assignment, and `--gcp-use-iap` to route SSH/SFTP through [Identity-Aware Proxy](https://cloud.google.com/iap/docs/using-tcp-forwarding) instead of dialing the instance IP — see [Route SSH/SFTP through IAP](gcp.md#optional-route-sshsftp-through-iap).
+**Gotchas:** running in a private-only VPC needs a Cloud NAT (Aerolab checks and aborts
+`cluster create` without one) and, if you also want SSH/SFTP to work without a
+VPN/peering, `--gcp-use-iap` to route through [Identity-Aware Proxy](https://cloud.google.com/iap/docs/using-tcp-forwarding) — it's independent of `--gcp-nopublic-ip`, so you opt into
+each separately. See [Route SSH/SFTP through IAP](gcp.md#optional-route-sshsftp-through-iap).
 
 → **[GCP Getting Started Guide](gcp.md)**
 
@@ -133,3 +138,6 @@ aerolab aerospike is-stable -w
 # View cluster status
 aerolab aerospike status
 ```
+
+Everything after that — starting/stopping, attach, file transfer, cleanup — works the same
+regardless of backend: see [Common Operations](common-operations.md).

--- a/docs/getting-started/aws.md
+++ b/docs/getting-started/aws.md
@@ -1,65 +1,34 @@
 # Getting Started with AWS Backend
 
-The AWS backend allows you to create and manage Aerospike clusters on Amazon Web Services (AWS) EC2 instances.
+The AWS backend creates and manages Aerospike clusters on EC2. Use it for production-like
+testing and performance benchmarks.
 
 ## Prerequisites
 
-### AWS Account Setup
-
-1. **AWS Account** - You need an active AWS account
-2. **AWS CLI** - Install the [AWS CLI](https://aws.amazon.com/cli/)
-3. **AWS Credentials** - Configure your AWS credentials
-
-### Configure AWS Credentials
-
-Aerolab uses standard AWS credential mechanisms. Set up your credentials using one of these methods:
-
-#### Method 1: AWS CLI Configuration (Recommended)
+1. An active AWS account
+2. The [AWS CLI](https://aws.amazon.com/cli/) installed
+3. Credentials configured — pick one:
 
 ```bash
+# Option 1: interactive (recommended)
 aws configure
-```
 
-This will prompt for:
-- AWS Access Key ID
-- AWS Secret Access Key
-- Default region (e.g., `us-east-1`)
-- Default output format (can be `json`)
-
-Credentials are stored in `~/.aws/credentials` and configuration in `~/.aws/config`.
-
-#### Method 2: Environment Variables
-
-```bash
+# Option 2: environment variables
 export AWS_ACCESS_KEY_ID=your-access-key-id
 export AWS_SECRET_ACCESS_KEY=your-secret-access-key
 export AWS_DEFAULT_REGION=us-east-1
-```
 
-#### Method 3: AWS Profile
-
-If you have multiple AWS accounts, use profiles:
-
-```bash
+# Option 3: a named profile (if you have multiple accounts)
 aws configure --profile myprofile
-```
-
-Then specify the profile when configuring Aerolab:
-
-```bash
+# then tell aerolab to use it:
 aerolab config backend -t aws -r us-east-1 -P myprofile
 ```
 
-### Required IAM Permissions
+Credentials live in `~/.aws/credentials`, config in `~/.aws/config`.
 
-Your AWS credentials need permissions for:
-
-- EC2 (instances, images, volumes, security groups, VPCs)
-- IAM (for instance profiles if used)
-- Route53 (for DNS management if used)
-- EKS (if using EKS cluster name)
-
-A minimal IAM policy would include:
+**Required IAM permissions:** EC2 (instances, images, volumes, security groups, VPCs), plus
+`iam:GetRole`/`iam:PassRole` if you use instance profiles, and Route53/EKS if you use DNS or
+an EKS cluster name. A minimal policy:
 
 ```json
 {
@@ -67,479 +36,141 @@ A minimal IAM policy would include:
   "Statement": [
     {
       "Effect": "Allow",
-      "Action": [
-        "ec2:*",
-        "iam:GetRole",
-        "iam:PassRole"
-      ],
+      "Action": ["ec2:*", "iam:GetRole", "iam:PassRole"],
       "Resource": "*"
     }
   ]
 }
 ```
 
-## Initial Setup
-
-### 1. Configure AWS Backend
-
-Configure Aerolab to use the AWS backend:
-
-```bash
-aerolab config backend -t aws -r us-east-1
-```
-
-This will:
-- Set AWS as the default backend
-- Set the default region to `us-east-1`
-- Use your AWS credentials from `~/.aws/credentials`
-
-### Using a Specific AWS Profile
-
-If you have multiple AWS accounts:
-
-```bash
-aerolab config backend -t aws -r us-east-1 -P myprofile
-```
-
-### Optional: Enable Inventory Cache
-
-If you're not sharing the AWS account with other users, enable inventory caching for faster operations:
-
-```bash
-aerolab config backend -t aws -r us-east-1 --inventory-cache
-```
-
-**Note**: Only use inventory cache if you're the sole user of the AWS account/project, as it caches resource state locally.
+## Gotchas
 
 ### Optional: Disable Public IPs
 
-If you want to operate only on private IPs:
+`--aws-nopublic-ip` stops Aerolab from requesting a public IP for new instances:
 
 ```bash
 aerolab config backend -t aws -r us-east-1 --aws-nopublic-ip
 ```
 
-### Optional: Set EKS Cluster Name
+**There is no AWS equivalent of GCP's IAP tunnel.** This flag only removes the public IP
+from the EC2 launch request — it does not set up SSM Session Manager, a VPN, or any other
+path to the instance. You must already have private network access (VPN, VPC peering,
+Direct Connect, or a bastion/Session Manager you configure yourself); Aerolab does not check
+reachability and has no fallback if you don't. Combining `--aws-nopublic-ip` with
+`-L`/`--public-ip`/`--external-ip` on `cluster create` is rejected with an error.
 
-If you want to use a specific EKS cluster name:
+### Flags don't persist across `config backend` runs
+
+`--aws-nopublic-ip` and `--skip-pricing` (and their GCP equivalents) are **not** merged with
+your last saved config — omitting a previously-set flag silently turns it back off. If
+you've configured the backend with `--aws-nopublic-ip` and later run `config backend` again
+to change something else (e.g. add `--inventory-cache`), you must repeat
+`--aws-nopublic-ip` too, or it reverts to requesting public IPs.
+
+## Quick Start
 
 ```bash
-aerolab config backend -t aws -r us-east-1 -P eks
+# 1. Configure the backend
+aerolab config backend -t aws -r us-east-1
+
+# 2. Create a 2-node cluster
+aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
+  -I t3a.xlarge \
+  --aws-disk type=gp3,size=20 \
+  --aws-expire=8h
+
+# 3. Wait for it to come up, then use it
+aerolab aerospike is-stable -w
+aerolab attach aql -n mydc -- -c "show namespaces"
+
+# 4. Tear it down when done
+aerolab cluster destroy -n mydc --force
 ```
 
-### 2. Verify Configuration
+`-I t3a.xlarge` picks the instance type, `--aws-disk type=gp3,size=20` sets a 20GB root
+disk, and `--aws-expire=8h` auto-destroys the cluster after 8 hours so you don't forget it.
 
-Check your backend configuration:
+## Configure the Backend
+
+```bash
+aerolab config backend -t aws -r us-east-1
+```
+
+Optional flags:
+
+| Flag | Effect |
+|------|--------|
+| `-P, --aws-profile` | Use a named AWS CLI profile instead of the default. |
+| `--inventory-cache` | Cache resource state locally for faster operations — only if you're the sole user of the account. |
+| `--aws-nopublic-ip` | See [Gotchas](#gotchas) above. |
+| `--skip-pricing` | Skip cost/pricing lookups (still returns instance-type/volume catalogs). |
+| `-r` (comma-separated) | Enable multiple regions, e.g. `us-east-1,us-west-2`. |
+
+Verify and check access:
 
 ```bash
 aerolab config backend
-```
-
-You should see:
-```
-Config.Backend.Type = aws
-Config.Backend.AWSProfile = 
-Config.Backend.Region = us-east-1
-Config.Backend.AWSNoPublicIps = false
-Config.Backend.SshKeyPath = ${HOME}/.config/aerolab
-```
-
-### 3. Check Access
-
-Verify you have access to AWS:
-
-```bash
 aerolab config backend -t aws --check-access
-```
-
-### 4. Clean Up Existing Resources (Optional)
-
-If you have existing Aerolab resources, clean them up:
-
-```bash
-aerolab inventory delete-project-resources -f
-```
-
-Or with expiry:
-
-```bash
-aerolab inventory delete-project-resources -f --expiry
 ```
 
 ## AWS-Specific Configuration
 
-### List Subnets
-
-View available subnets:
-
-```bash
-aerolab config aws list-subnets
-```
-
-### List Security Groups
-
-View existing security groups:
+Security groups are managed with `config aws`:
 
 ```bash
 aerolab config aws list-security-groups
-```
-
-### Create Security Groups
-
-Create a security group for Aerospike:
-
-```bash
 aerolab config aws create-security-groups -n aerolab-sg -p 3000-3005
-```
-
-This creates a security group allowing ports 3000-3005.
-
-### Lock Security Groups
-
-Lock a security group to prevent deletion:
-
-```bash
 aerolab config aws lock-security-groups -n aerolab-sg
-```
-
-### Delete Security Groups
-
-Delete a security group:
-
-```bash
 aerolab config aws delete-security-groups -n aerolab-sg
 ```
 
-## Creating Your First Cluster
+## Creating Clusters
 
-### Basic Cluster Creation
+Beyond the Quick Start example, common `cluster create` additions:
 
-Create a simple 2-node cluster:
+| Need | Flag(s) |
+|------|---------|
+| Multiple disks | repeat `--aws-disk type=gp3,size=100,count=3` |
+| Specific subnet | `-U subnet-12345678` |
+| Custom security group | `--secgroup-name aerolab-sg` |
+| Public IP (overrides backend default) | `-L` |
+| Spot instances (cheaper) | `--aws-spot-instance` |
+| Tags | repeat `--tags Key=Value` |
+| EFS volume mount | `--aws-efs-create --aws-efs-mount myefs:/mnt/efs` |
 
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  -I t3a.xlarge \
-  --aws-disk type=gp3,size=20 \
-  --aws-expire=8h
-```
+## Resource Expiry Automation
 
-This command:
-- Creates 2 nodes (`-c 2`)
-- Uses Ubuntu 24.04 (`-d ubuntu -i 24.04`)
-- Installs Aerospike version 8.x (`-v '8.*'`)
-- Uses `t3a.xlarge` instance type (`-I t3a.xlarge`)
-- Creates 20GB GP3 root disk (`--aws-disk type=gp3,size=20`)
-- Sets expiry to 8 hours (`--aws-expire=8h`)
-
-### Multiple Disks
-
-Add multiple disks:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  -I t3a.xlarge \
-  --aws-disk type=gp3,size=20 \
-  --aws-disk type=gp3,size=100,count=3 \
-  --aws-expire=8h
-```
-
-This creates:
-- One 20GB GP2 root disk
-- Three 100GB GP3 data disks
-
-### Custom Subnet
-
-Specify a subnet:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  -I t3a.xlarge \
-  -U subnet-12345678 \
-  --aws-disk type=gp3,size=20 \
-  --aws-expire=8h
-```
-
-### Custom Security Groups
-
-Add custom security groups:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  -I t3a.xlarge \
-  --secgroup-name aerolab-sg \
-  --aws-disk type=gp3,size=20 \
-  --aws-expire=8h
-```
-
-### Public IP
-
-Enable public IP access:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  -I t3a.xlarge \
-  -L \
-  --aws-disk type=gp3,size=20 \
-  --aws-expire=8h
-```
-
-### Spot Instances
-
-Use spot instances for cost savings:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  -I t3a.xlarge \
-  --aws-spot-instance \
-  --aws-disk type=gp3,size=20 \
-  --aws-expire=8h
-```
-
-### Custom Tags
-
-Add custom tags:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  -I t3a.xlarge \
-  --tags Environment=Development \
-  --tags Team=Platform \
-  --aws-disk type=gp3,size=20 \
-  --aws-expire=8h
-```
-
-## Resource Expiry Management
-
-### Install Expiry Automation
-
-Install automated resource expiry:
+Installs a Lambda that auto-destroys expired resources:
 
 ```bash
 aerolab config aws expiry-install
-```
-
-This installs a Lambda function that automatically cleans up expired resources.
-
-### List Expiry Rules
-
-View expiry rules:
-
-```bash
 aerolab config aws expiry-list
-```
-
-### Set Expiry Run Frequency
-
-Configure how often expiry runs:
-
-```bash
-aerolab config aws expiry-run-frequency -f 20
-```
-
-This sets expiry to run every 20 minutes.
-
-### Remove Expiry
-
-Remove expiry automation:
-
-```bash
+aerolab config aws expiry-run-frequency -f 20   # minutes
 aerolab config aws expiry-remove
 ```
 
-## Starting and Stopping Clusters
+## Next: Lifecycle, Attach, Files, Cleanup
 
-### Start Cluster
+Starting/stopping, controlling the Aerospike service, `attach` (shell/aql/asinfo/asadm),
+file upload/download, and cleanup are identical across every backend — see
+[Common Operations](common-operations.md). One AWS-specific note: stopping instances
+doesn't delete their EBS volumes, so you're still billed until you `destroy` or let expiry
+run.
 
-Start all nodes in the cluster:
-
-```bash
-aerolab cluster start
-```
-
-### Stop Cluster
-
-Stop all nodes:
-
-```bash
-aerolab cluster stop
-```
-
-**Note**: Stopping instances in AWS doesn't delete them, but you'll still be charged for EBS volumes. Use expiry or destroy to completely remove resources.
-
-## Managing Aerospike Service
-
-### Start Aerospike
-
-```bash
-aerolab aerospike start
-```
-
-### Stop Aerospike
-
-```bash
-aerolab aerospike stop
-```
-
-### Restart Aerospike
-
-```bash
-aerolab aerospike restart
-```
-
-### Check Status
-
-```bash
-aerolab aerospike status
-```
-
-### Wait for Cluster Stability
-
-```bash
-aerolab aerospike is-stable -w
-```
-
-## Connecting to Nodes
-
-### Shell Access
-
-```bash
-aerolab attach shell -n mydc -l 1
-```
-
-### Aerospike Tools
-
-```bash
-# AQL
-aerolab attach aql -n mydc -- -c "show namespaces"
-
-# asinfo
-aerolab attach asinfo -n mydc -- -v "cluster-stable"
-
-# asadm
-aerolab attach asadm -n mydc -- -e info
-```
-
-## File Operations
-
-### Upload Files
-
-```bash
-aerolab files upload -n mydc local-file.txt /tmp/remote-file.txt
-```
-
-### Download Files
-
-```bash
-aerolab files download -n mydc /tmp/remote-file.txt ./local-dir/
-```
-
-### Sync Files
-
-```bash
-aerolab files sync -n mydc -l 1 /tmp/file.txt
-```
-
-## AWS-Specific Features
-
-### EFS (Elastic File System)
-
-Create and mount EFS volumes:
-
-```bash
-# Create cluster with EFS mount
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  -I t3a.xlarge \
-  --aws-efs-create \
-  --aws-efs-mount myefs:/mnt/efs \
-  --aws-disk type=gp3,size=20 \
-  --aws-expire=8h
-```
-
-### Add Public IP Later
-
-Add public IP to existing cluster:
-
-```bash
-aerolab cluster add public-ip -n mydc
-```
-
-### Add Firewall Rules
-
-Add firewall rules to cluster:
-
-```bash
-aerolab cluster add firewall -n mydc -f aerolab-sg
-```
-
-## Cleanup
-
-### Destroy a Cluster
-
-```bash
-aerolab cluster destroy -n mydc --force
-```
-
-### Clean Up All Resources
-
-```bash
-aerolab inventory delete-project-resources -f --expiry
-```
-
-## Common Workflows
-
-### Complete Workflow Example
-
-```bash
-# 1. Configure backend
-aerolab config backend -t aws -r us-east-1
-
-# 2. Create security group
-aerolab config aws create-security-groups -n aerolab-sg -p 3000-3005
-
-# 3. Create cluster
-aerolab cluster create -c 3 -d ubuntu -i 24.04 -v '8.*' \
-  -I t3a.xlarge \
-  --aws-disk type=gp3,size=20 \
-  --aws-disk type=gp3,size=100,count=3 \
-  --secgroup-name aerolab-sg \
-  --aws-expire=8h
-
-# 4. Start cluster
-aerolab cluster start
-
-# 5. Start Aerospike
-aerolab aerospike start
-
-# 6. Wait for stability
-aerolab aerospike is-stable -w
-
-# 7. Check status
-aerolab aerospike status
-
-# 8. Use the cluster
-aerolab attach aql -n mydc -- -c "show namespaces"
-
-# 9. Clean up
-aerolab cluster destroy -n mydc --force
-```
+Cluster-level extras: `aerolab cluster add public-ip -n mydc` and
+`aerolab cluster add firewall -n mydc -f aerolab-sg` add these after the fact.
 
 ## Troubleshooting
 
 ### Credential Issues
 
-If you see authentication errors:
-
 ```bash
-# Check AWS credentials
 aws sts get-caller-identity
-
-# Verify credentials file
 cat ~/.aws/credentials
 ```
 
 ### Region Issues
-
-If resources aren't found, check you're in the right region:
 
 ```bash
 aerolab config backend
@@ -547,15 +178,11 @@ aerolab config backend
 
 ### Permission Issues
 
-If you see permission denied errors, check your IAM permissions:
-
 ```bash
 aws iam get-user
 ```
 
 ### Instance Type Availability
-
-Check available instance types in your region:
 
 ```bash
 aerolab inventory instance-types
@@ -563,16 +190,11 @@ aerolab inventory instance-types
 
 ### Network Issues
 
-If nodes can't communicate:
-
-1. Check security groups
-2. Verify VPC configuration
-3. Check subnet settings
+Check security groups, VPC configuration, and subnet settings.
 
 ## Next Steps
 
-- Explore [cluster management commands](commands/cluster.md)
-- Learn about [Aerospike daemon controls](commands/aerospike.md)
-- Check out [AWS-specific volume management](commands/volumes.md)
-- See [Aerospike Cloud integration](cloud/README.md)
-
+- [Common Operations](common-operations.md) - lifecycle, attach, files, cleanup
+- [Cluster management commands](../commands/cluster.md)
+- [AWS-specific volume management](../commands/volumes.md)
+- [Aerospike Cloud integration](../cloud/README.md)

--- a/docs/getting-started/common-operations.md
+++ b/docs/getting-started/common-operations.md
@@ -1,0 +1,109 @@
+# Common Operations (All Backends)
+
+Once a cluster exists, these commands behave the same on Docker, AWS, and GCP. The
+backend-specific getting started guides ([Docker](docker.md), [AWS](aws.md), [GCP](gcp.md))
+link here instead of repeating this section.
+
+## Starting and Stopping Clusters
+
+```bash
+# Start all nodes
+aerolab cluster start
+
+# Start specific nodes
+aerolab cluster start -n mydc -l 1-2
+
+# Stop all nodes
+aerolab cluster stop
+
+# Stop specific nodes
+aerolab cluster stop -n mydc -l 1-2
+```
+
+**Note (AWS/GCP):** stopping instances doesn't delete them — you're still billed for
+attached disks/EBS volumes. Use expiry or `cluster destroy` to fully remove resources.
+
+## Managing the Aerospike Service
+
+```bash
+aerolab aerospike start
+aerolab aerospike stop
+aerolab aerospike restart
+aerolab aerospike status
+
+# Wait for the cluster to report stable
+aerolab aerospike is-stable -w
+
+# With a timeout (seconds)
+aerolab aerospike is-stable -w -o 30
+```
+
+## Connecting to Nodes
+
+```bash
+# Shell access
+aerolab attach shell -n mydc -l 1
+
+# Run a single command
+aerolab attach shell -n mydc -l 1 -- ls /tmp
+
+# AQL (Aerospike Query Language)
+aerolab attach aql -n mydc -- -c "show namespaces"
+
+# asinfo
+aerolab attach asinfo -n mydc -- -v "cluster-stable"
+
+# asadm (Aerospike Admin)
+aerolab attach asadm -n mydc -- -e info
+```
+
+## File Operations
+
+```bash
+# Upload
+aerolab files upload -n mydc local-file.txt /tmp/remote-file.txt
+
+# Download
+aerolab files download -n mydc /tmp/remote-file.txt ./local-dir/
+
+# Sync a file from node 1 to every other node in the cluster
+aerolab files sync -n mydc -l 1 /tmp/file.txt
+```
+
+## Configuration Management
+
+```bash
+# View the running config
+aerolab attach shell -n mydc -- cat /etc/aerospike/aerospike.conf
+
+# Adjust a parameter live
+aerolab conf adjust set network.heartbeat.interval 250
+
+# Fix mesh configuration after nodes changed
+aerolab conf fix-mesh
+
+# Assign rack IDs
+aerolab conf rackid -l 1-2 -i 1
+aerolab conf rackid -l 3-4 -i 2
+```
+
+## Cleanup
+
+```bash
+# Destroy one cluster
+aerolab cluster destroy -n mydc --force
+
+# Remove every Aerolab-managed resource in the current backend/project
+aerolab inventory delete-project-resources -f
+
+# Same, but only resources past their expiry (AWS/GCP)
+aerolab inventory delete-project-resources -f --expiry
+```
+
+## See Also
+
+- [Cluster Management](../commands/cluster.md)
+- [Aerospike Daemon Controls](../commands/aerospike.md)
+- [Configuration File Management](../commands/conf.md)
+- [File Operations](../commands/files.md)
+- [Attach Commands](../commands/attach.md)

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -1,373 +1,102 @@
 # Getting Started with Docker Backend
 
-The Docker backend is the quickest way to get started with Aerolab. It requires Docker, Docker Desktop, Podman, or Podman Desktop to be installed and running.
+Docker is the fastest way to run Aerolab: no cloud account, no credentials, clusters in
+seconds. It requires Docker, Docker Desktop, Podman, or Podman Desktop to be installed and
+running.
 
 ## Prerequisites
 
-Install one of the following container runtimes:
+Install one of:
 
 - **Docker** - [Install Docker](https://docs.docker.com/get-docker/)
 - **Docker Desktop** - [Install Docker Desktop](https://www.docker.com/products/docker-desktop/)
 - **Podman** - [Install Podman](https://podman.io/getting-started/installation)
 - **Podman Desktop** - [Install Podman Desktop](https://podman.io/getting-started/installation)
 
-Verify installation:
-
 ```bash
-# For Docker
-docker --version
-
-# For Podman
-podman --version
+docker --version   # or: podman --version
 ```
 
-## Initial Setup
+## Gotchas
 
-### 1. Configure Docker Backend
+- **Podman is auto-detected.** Aerolab inspects the daemon it connects to and adapts
+  automatically — you don't tell it whether it's talking to Docker or Podman.
+- **Architecture mismatches.** By default Aerolab builds/runs images for your host's native
+  architecture. If you need the other one (e.g. running arm64 images on an amd64 host) your
+  Docker/Podman install needs multiarch (QEMU) support, and you must force it explicitly:
+  `aerolab config backend -t docker --docker-arch amd64` (or `arm64`).
+- **WSL2**: if you don't pass `--temp-dir`, Aerolab detects WSL2 automatically (via `uname -r`)
+  and switches its temp directory to `~/.aerolab.tmp` for you — no action needed.
+- **Permission denied talking to the Docker socket** usually means your user isn't in the
+  `docker` group — see [Troubleshooting](#permission-issues) below.
 
-Configure Aerolab to use the Docker backend:
+## Quick Start
+
+```bash
+# 1. Configure the backend
+aerolab config backend -t docker
+
+# 2. Create a 2-node cluster
+aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*'
+
+# 3. Wait for it to come up, then use it
+aerolab aerospike is-stable -w
+aerolab attach aql -n mydc -- -c "show namespaces"
+
+# 4. Tear it down when done
+aerolab cluster destroy -n mydc --force
+```
+
+`-c 2` creates 2 nodes, `-d ubuntu -i 24.04` picks the OS image, `-v '8.*'` installs the
+latest Aerospike 8.x, and the cluster is named `mydc` unless you pass `-n`.
+
+## Configure the Backend
 
 ```bash
 aerolab config backend -t docker
 ```
 
-This will:
-- Set Docker as the default backend
-- Prepare the local environment for cluster management
+Optional flags:
 
-### Optional: Enable Inventory Cache
+| Flag | Effect |
+|------|--------|
+| `--inventory-cache` | Cache resource state locally for faster operations. Only use this if you're not sharing the Docker host with other users. |
+| `--docker-arch amd64\|arm64` | Force a specific architecture (see [Gotchas](#gotchas)). |
+| `--docker-registry-region na\|eu\|disabled` | Region for the pre-built template image registry. |
+| `-d, --temp-dir <path>` | Custom temp directory (see the WSL2 gotcha above). |
 
-If you're not sharing Docker resources with other users, you can enable inventory caching for faster operations:
-
-```bash
-aerolab config backend -t docker --inventory-cache
-```
-
-### Optional: Set Docker Architecture
-
-If you need to force a specific architecture (amd64 or arm64):
-
-```bash
-aerolab config backend -t docker --docker-arch amd64
-```
-
-### 2. Verify Configuration
-
-Check your backend configuration:
+Verify what's configured:
 
 ```bash
 aerolab config backend
 ```
 
-You should see:
-```
-Config.Backend.Type = docker
-Config.Backend.SshKeyPath = ${HOME}/.config/aerolab
-```
-
-### 3. Clean Up Existing Resources (Optional)
-
-If you have existing Aerolab resources, clean them up:
+## Creating Clusters
 
 ```bash
-aerolab inventory delete-project-resources -f
-```
-
-## Creating Your First Cluster
-
-### Basic Cluster Creation
-
-Create a simple 2-node cluster:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*'
-```
-
-This command:
-- Creates 2 nodes (`-c 2`)
-- Uses Ubuntu 24.04 (`-d ubuntu -i 24.04`)
-- Installs Aerospike version 8.x (`-v '8.*'`)
-- Default cluster name is `mydc`
-- Auto-starts Aerospike after creation
-
-### Custom Cluster Name
-
-Specify a custom cluster name:
-
-```bash
+# Custom name
 aerolab cluster create -n mycluster -c 2 -d ubuntu -i 24.04 -v '8.*'
-```
 
-### Create Without Auto-Start
-
-If you want to manually start Aerospike later:
-
-```bash
+# Don't auto-start Aerospike after creation
 aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' --start n
-```
 
-### List Available Versions
-
-List available Aerospike versions:
-
-```bash
+# See what Aerospike versions are available
 aerolab installer list-versions
-```
 
-### List Your Clusters
-
-Check what clusters exist:
-
-```bash
+# List clusters / all resources
 aerolab cluster list
-```
-
-### View All Resources
-
-View all clusters, instances, and images:
-
-```bash
 aerolab inventory list
 ```
 
-## Starting and Stopping Clusters
-
-### Start Cluster
-
-Start all nodes in the cluster:
-
-```bash
-aerolab cluster start
-```
-
-Or start specific nodes:
-
-```bash
-aerolab cluster start -n mydc -l 1-2
-```
-
-### Stop Cluster
-
-Stop all nodes:
-
-```bash
-aerolab cluster stop
-```
-
-Or stop specific nodes:
-
-```bash
-aerolab cluster stop -n mydc -l 1-2
-```
-
-## Managing Aerospike Service
-
-### Start Aerospike
-
-Start the Aerospike service on all nodes:
-
-```bash
-aerolab aerospike start
-```
-
-### Stop Aerospike
-
-Stop the Aerospike service:
-
-```bash
-aerolab aerospike stop
-```
-
-### Restart Aerospike
-
-Restart the Aerospike service:
-
-```bash
-aerolab aerospike restart
-```
-
-### Check Status
-
-Check Aerospike service status:
-
-```bash
-aerolab aerospike status
-```
-
-### Wait for Cluster Stability
-
-Wait for the cluster to become stable:
-
-```bash
-aerolab aerospike is-stable -w
-```
-
-With timeout (30 seconds):
-
-```bash
-aerolab aerospike is-stable -w -o 30
-```
-
-## Connecting to Nodes
-
-### Shell Access
-
-Connect to a node via shell:
-
-```bash
-aerolab attach shell -n mydc -l 1
-```
-
-Or run a command:
-
-```bash
-aerolab attach shell -n mydc -l 1 -- ls /tmp
-```
-
-### Aerospike Tools
-
-Use Aerospike command-line tools:
-
-```bash
-# AQL (Aerospike Query Language)
-aerolab attach aql -n mydc -- -c "show namespaces"
-
-# asinfo
-aerolab attach asinfo -n mydc -- -v "cluster-stable"
-
-# asadm (Aerospike Admin)
-aerolab attach asadm -n mydc -- -e info
-```
-
-## File Operations
-
-### Upload Files
-
-Upload a file to nodes:
-
-```bash
-aerolab files upload -n mydc local-file.txt /tmp/remote-file.txt
-```
-
-### Download Files
-
-Download files from nodes:
-
-```bash
-aerolab files download -n mydc /tmp/remote-file.txt ./local-dir/
-```
-
-### Sync Files
-
-Sync files across nodes in a cluster:
-
-```bash
-aerolab files sync -n mydc -l 1 /tmp/file.txt
-```
-
-This syncs the file from node 1 to all other nodes.
-
-## Configuration Management
-
-### View Configuration
-
-View the current Aerospike configuration:
-
-```bash
-aerolab attach shell -n mydc -- cat /etc/aerospike/aerospike.conf
-```
-
-### Adjust Configuration Parameters
-
-Modify configuration parameters:
-
-```bash
-aerolab conf adjust set network.heartbeat.interval 250
-```
-
-### Fix Mesh Configuration
-
-Automatically fix mesh configuration:
-
-```bash
-aerolab conf fix-mesh
-```
-
-### Set Rack IDs
-
-Assign rack IDs to nodes:
-
-```bash
-aerolab conf rackid -l 1-2 -i 1
-aerolab conf rackid -l 3-4 -i 2
-```
-
-## Cleanup
-
-### Destroy a Cluster
-
-Destroy a cluster and all its resources:
-
-```bash
-aerolab cluster destroy -n mydc --force
-```
-
-### Clean Up All Resources
-
-Remove all Aerolab resources:
-
-```bash
-aerolab inventory delete-project-resources -f
-```
-
-### Clean Up Docker Networks
-
-Clean up unused Docker networks:
-
-```bash
-aerolab config docker prune-networks
-```
-
-## Common Workflows
-
-### Complete Workflow Example
-
-```bash
-# 1. Configure backend
-aerolab config backend -t docker
-
-# 2. Create cluster
-aerolab cluster create -c 3 -d ubuntu -i 24.04 -v '8.*'
-
-# 3. Wait for cluster stability
-aerolab aerospike is-stable -w
-
-# 4. Check status
-aerolab aerospike status
-
-# 5. Configure rack IDs
-aerolab conf rackid -l 1 -i 1
-aerolab conf rackid -l 2 -i 2
-aerolab conf rackid -l 3 -i 3
-
-# 6. Restart to apply changes
-aerolab aerospike restart -n mydc
-
-# 7. Wait for stability again
-aerolab aerospike is-stable -w
-
-# 8. Use the cluster
-aerolab attach aql -n mydc -- -c "show namespaces"
-
-# 9. Clean up when done
-aerolab cluster destroy -n mydc --force
-```
+## Next: Lifecycle, Attach, Files, Cleanup
+
+Starting/stopping, controlling the Aerospike service, `attach` (shell/aql/asinfo/asadm),
+file upload/download, and cleanup are identical across every backend — see
+[Common Operations](common-operations.md).
 
 ## Troubleshooting
 
 ### Docker Not Running
-
-If you see connection errors, ensure Docker is running:
 
 ```bash
 docker ps
@@ -375,26 +104,26 @@ docker ps
 
 ### Permission Issues
 
-If you see permission denied errors, add your user to the docker group:
-
 ```bash
 sudo usermod -aG docker $USER
 ```
 
-Then log out and log back in.
+Then log out and back in.
 
 ### Network Issues
-
-If nodes can't communicate, check Docker networks:
 
 ```bash
 docker network ls
 aerolab config docker list-networks
 ```
 
-### Clean Up Failed Resources
+Clean up unused Docker networks:
 
-If cluster creation fails, clean up:
+```bash
+aerolab config docker prune-networks
+```
+
+### Clean Up Failed Resources
 
 ```bash
 aerolab inventory delete-project-resources -f
@@ -402,8 +131,7 @@ aerolab inventory delete-project-resources -f
 
 ## Next Steps
 
-- Explore [cluster management commands](commands/cluster.md)
-- Learn about [Aerospike daemon controls](commands/aerospike.md)
-- Check out [configuration management](commands/conf.md)
-- See [advanced features](commands/) for more options
-
+- [Common Operations](common-operations.md) - lifecycle, attach, files, cleanup
+- [Cluster management commands](../commands/cluster.md)
+- [Aerospike daemon controls](../commands/aerospike.md)
+- [Configuration management](../commands/conf.md)

--- a/docs/getting-started/gcp.md
+++ b/docs/getting-started/gcp.md
@@ -1,229 +1,78 @@
 # Getting Started with GCP Backend
 
-The GCP backend allows you to create and manage Aerospike clusters on Google Cloud Platform (GCP) Compute Engine.
+The GCP backend creates and manages Aerospike clusters on Compute Engine. Use it for
+production-like testing and performance benchmarks.
 
 ## Prerequisites
 
-### GCP Account Setup
-
-1. **GCP Account** - You need an active Google Cloud Platform account
-2. **GCP Project** - Create or select a GCP project
-3. **Google Cloud CLI** - Install and configure the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install)
-4. **Authentication** - Aerolab uses Application Default Credentials (ADC) via the gcloud CLI
-
-### Authentication Setup
-
-Aerolab requires service account authentication using Application Default Credentials. You must authenticate using the gcloud CLI before using Aerolab:
+1. An active Google Cloud Platform account and project
+2. The [Google Cloud CLI](https://cloud.google.com/sdk/docs/install) installed
+3. Authenticate with Application Default Credentials (ADC) — Aerolab uses these, not your
+   `gcloud` login, to talk to GCP:
 
 ```bash
 gcloud auth application-default login
-```
-
-This command will:
-- Open your browser for authentication
-- Store credentials locally for use by Aerolab
-- Allow Aerolab to authenticate with GCP services
-
-**Note**: If you see an authentication error, ensure you've run `gcloud auth application-default login` first. See the [troubleshooting section](#authentication-issues) for more details.
-
-### Required GCP Services (APIs)
-
-AeroLab relies on several Google Cloud APIs (Compute Engine, Service Usage,
-Cloud Billing, IAP, and the Cloud Functions stack used for resource expiry).
-AeroLab can enable the ones it needs for you, or you can enable them ahead of
-time. For the full list of services, what each is used for, and how automatic
-enablement works, see [GCP Services (APIs) Required by AeroLab](gcp-services.md).
-
-## Initial Setup
-
-### 1. Authenticate with GCP
-
-Before configuring Aerolab, authenticate with Google Cloud using Application Default Credentials:
-
-```bash
-gcloud auth application-default login
-```
-
-This will open your browser for authentication. After completing the authentication flow, your credentials will be stored locally and used by Aerolab.
-
-**Note**: You may need to specify a project when authenticating:
-```bash
+# or, to set the project at the same time:
 gcloud auth application-default login --project=your-project-id
 ```
 
-### 2. Configure GCP Backend
+4. **Required GCP APIs**: Aerolab needs Compute Engine, Service Usage, Cloud Billing, IAP,
+   and (for expiry automation) the Cloud Functions stack. Aerolab can enable what's missing
+   for you — see [GCP Services (APIs) Required by AeroLab](gcp-services.md) for the full
+   list and the `--gcp-auto-enable-services` flag.
 
-Configure Aerolab to use the GCP backend:
+## Gotchas
 
-```bash
-aerolab config backend -t gcp -r us-central1 -o your-project-id
-```
+### `--gcp-nopublic-ip` and `--gcp-use-iap` are independent
 
-This will:
-- Set GCP as the default backend
-- Set the default region to `us-central1`
-- Set the project ID to `your-project-id`
-- Use Application Default Credentials for authentication
+`--gcp-use-iap` is the **sole** trigger for routing SSH/SFTP through IAP. Aerolab does
+**not** auto-route through IAP just because public IPs are disabled — you must opt into
+each independently:
 
-**Note**: Replace `your-project-id` with your actual GCP project ID.
-
-### Optional: Enable Inventory Cache
-
-If you're not sharing the GCP project with other users, enable inventory caching:
-
-```bash
-aerolab config backend -t gcp -r us-central1 -o your-project-id --inventory-cache
-```
-
-**Note**: Only use inventory cache if you're the sole user of the GCP project, as it caches resource state locally.
-
-### Optional: Automatically Enable Required Services
-
-By default, if a required GCP service (API) is not enabled, AeroLab prompts you
-interactively for confirmation before enabling it, and errors out in
-non-interactive contexts. To let AeroLab enable missing services automatically
-without prompting (including in non-interactive contexts), add
-`--gcp-auto-enable-services`:
-
-```bash
-aerolab config backend -t gcp -r us-central1 -o your-project-id --gcp-auto-enable-services
-```
-
-See [GCP Services (APIs) Required by AeroLab](gcp-services.md) for the full list
-of services and the required IAM permission.
-
-### Optional: Specify Multiple Regions
-
-You can specify multiple regions:
-
-```bash
-aerolab config backend -t gcp -r us-central1,us-east1,us-west1 -o your-project-id
-```
-
-### 2. Verify Configuration
-
-Check your backend configuration:
-
-```bash
-aerolab config backend
-```
-
-You should see:
-```
-Config.Backend.Type = gcp
-Config.Backend.Project = your-project-id
-Config.Backend.Region = us-central1
-Config.Backend.GCPAuthMethod = service-account
-Config.Backend.SshKeyPath = ${HOME}/.config/aerolab
-```
-
-### 3. Check Access
-
-Verify you have access to GCP:
-
-```bash
-aerolab config backend -t gcp --check-access
-```
-
-### 4. Clean Up Existing Resources (Optional)
-
-If you have existing Aerolab resources:
-
-```bash
-aerolab inventory delete-project-resources -f
-```
-
-Or with expiry:
-
-```bash
-aerolab inventory delete-project-resources -f --expiry
-```
+| `--gcp-nopublic-ip` | `--gcp-use-iap` | Behaviour |
+| --- | --- | --- |
+| no | no | Default: instances get public IPs; SSH dials the public IP. |
+| yes | no | No public IP; SSH attempts the private IP and fails unless you have VPN/peering. |
+| no | yes | Instances still get public IPs, but SSH/SFTP routes through IAP anyway. |
+| yes | yes | Canonical no-public-IP, IAP-only deployment. |
 
 ### Optional: Route SSH/SFTP through IAP
 
-For deployments where the operator's desktop cannot reach VM IPs directly (no
-public IPs, no VPN/peering), aerolab can route SSH and SFTP through Google
-[Identity-Aware Proxy TCP forwarding](https://cloud.google.com/iap/docs/using-tcp-forwarding):
-
-```bash
-aerolab config backend -t gcp -r us-central1 -o your-project-id --gcp-use-iap
-```
-
-You can combine this with `--gcp-nopublic-ip` for a no-public-IP, IAP-only
-deployment:
+For deployments where your desktop can't reach VM IPs directly (no public IPs, no
+VPN/peering), route SSH/SFTP through Google [Identity-Aware Proxy TCP forwarding](https://cloud.google.com/iap/docs/using-tcp-forwarding):
 
 ```bash
 aerolab config backend -t gcp -r us-central1 -o your-project-id \
   --gcp-nopublic-ip --gcp-use-iap
 ```
 
-`--gcp-use-iap` is the **sole** trigger for IAP usage. It is intentionally
-independent of `--gcp-nopublic-ip` -- aerolab does **not** auto-route through
-IAP just because public IPs were disabled. The four combinations:
+**One-time prerequisites per project**, none of which Aerolab does for you except the first:
 
-| `--gcp-nopublic-ip` | `--gcp-use-iap` | Behaviour |
-| --- | --- | --- |
-| no  | no  | Default: instances get public IPs; SSH dials the public IP. |
-| yes | no  | No public IP; SSH attempts the private IP and will fail unless you have VPN/peering. |
-| no  | yes | Instances still get public IPs but SSH/SFTP routes through IAP. |
-| yes | yes | Canonical no-public-IP, IAP-only deployment. |
-
-**IAP prerequisites** (one-time, per project):
-
-1. The IAP API (`iap.googleapis.com`) must be enabled in the project. aerolab
-   enables it for you the first time you run `aerolab config backend ...
-   --gcp-use-iap` (prompting for confirmation when interactive, or
-   automatically when `--gcp-auto-enable-services` is set), provided the calling
-   principal has `roles/serviceusage.serviceUsageAdmin` (or the equivalent
-   `serviceusage.services.enable` permission). If your principal cannot enable
-   APIs, ask a project owner to run:
-   ```bash
-   gcloud services enable iap.googleapis.com --project=your-project-id
-   ```
-   See [GCP Services (APIs) Required by AeroLab](gcp-services.md) for details.
-2. Grant `roles/iap.tunnelResourceAccessor` to the principal aerolab runs as
-   (your user, or a service account):
+1. **Enable the IAP API.** Aerolab enables `iap.googleapis.com` automatically the first time
+   you run `config backend ... --gcp-use-iap` (prompting first if interactive, silently if
+   `--gcp-auto-enable-services` is set). If your principal can't enable APIs, ask an owner to
+   run `gcloud services enable iap.googleapis.com --project=your-project-id`.
+2. **Grant the IAM role.** You must do this yourself — Aerolab does not:
    ```bash
    gcloud projects add-iam-policy-binding your-project-id \
      --member=user:you@example.com \
      --role=roles/iap.tunnelResourceAccessor
    ```
-3. Firewall: aerolab's default `aerolab-default` rule already allows tcp:22
-   from `0.0.0.0/0`, which covers IAP's source range `35.235.240.0/20`. No
-   extra rule is required for IAP to function.
+3. **Firewall.** IAP connects from the range `35.235.240.0/20`. Aerolab's default
+   `aerolab-default` rule already allows `tcp:22` from `0.0.0.0/0`, which covers it — but
+   **if you use a locked-down custom firewall, you must add this range yourself**; Aerolab
+   does not add it automatically.
 
-**Smoke test**:
+If `attach shell` reports a 403 from `tunnel.cloudproxy.app`, recheck step 2. If
+`config backend` itself fails to enable the API, recheck that your principal has
+`roles/serviceusage.serviceUsageAdmin` (step 1).
 
-```bash
-# Configure (no public IPs + IAP-only). On the first run with --gcp-use-iap,
-# aerolab will enable iap.googleapis.com automatically; this can take 30-60s.
-aerolab config backend -t gcp -r us-central1 -o your-project-id \
-  --gcp-nopublic-ip --gcp-use-iap
+### Cloud NAT is required for `--gcp-nopublic-ip`
 
-# Create a small cluster
-aerolab cluster create -n iaptest -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  --instance e2-standard-4 --gcp-disk type=pd-ssd,size=20 --gcp-expire=2h
-
-# Attach -- traffic flows over the IAP tunnel
-aerolab attach shell -n iaptest -l 1
-```
-
-If `aerolab attach shell` reports a 403 from `tunnel.cloudproxy.app`, recheck
-the `roles/iap.tunnelResourceAccessor` binding; if `aerolab config backend`
-itself fails with a service-enable error, recheck that the principal has
-permission to enable APIs (or ask a project owner to enable
-`iap.googleapis.com` ahead of time).
-
-### Cloud NAT (required when running without public IPs)
-
-VMs created with `--gcp-nopublic-ip` have no outbound internet by default.
-The install script needs to reach `download.aerospike.com`, the distro
-package mirrors, and (for AGI) Grafana / Loki release endpoints, so without
-egress the create hangs for minutes on apt-get / curl before timing out.
-
-To prevent that, aerolab queries Cloud Routers in the target region at create
-time and **aborts the create** if no Cloud NAT covers the chosen subnet. Set
-up NAT once per (project, region, network):
+Instances without a public IP have no outbound internet by default, but the install script
+needs to reach `download.aerospike.com` and distro package mirrors. To catch this early,
+Aerolab checks for a Cloud NAT covering the target subnet **before** every `cluster create`
+and aborts if none is found:
 
 ```bash
 gcloud compute routers create aerolab-router \
@@ -235,465 +84,159 @@ gcloud compute routers nats create aerolab-nat \
   --enable-logging --project=your-project-id
 ```
 
-Egress already provided by VPN, VPC peering, an internal proxy, or a
-hand-rolled NAT VM is invisible to `compute.routers.list`. Bypass the check
-in those cases with `AEROLAB_SKIP_NAT_CHECK=1`. See the
-[environment variables reference](../reference/environment-variables.md#aerolab_skip_nat_check)
-for details.
+Two caveats worth knowing:
+
+- Egress from a VPN, VPC peering, an internal proxy, or a hand-rolled NAT VM is invisible to
+  this check (it only looks at `compute.routers.list`). Bypass it with
+  `AEROLAB_SKIP_NAT_CHECK=1` — see the
+  [environment variables reference](../reference/environment-variables.md#aerolab_skip_nat_check).
+- If the check itself can't run (e.g. your principal lacks `compute.routers.list`
+  permission, or a transient API error), Aerolab **fails open** and lets the create proceed
+  without confirming NAT actually exists. Don't rely on the check as your only signal that
+  egress is set up correctly.
+
+### Flags don't persist across `config backend` runs
+
+`--gcp-nopublic-ip`, `--gcp-use-iap`, `--gcp-auto-enable-services`, and `--skip-pricing` are
+**not** merged with your last saved config — omitting a previously-set flag on a later
+`config backend` call silently turns it back off. If you reconfigure the backend for any
+reason (e.g. to add a region), repeat every flag you want to keep.
+
+## Quick Start
+
+```bash
+# 1. Authenticate (one time)
+gcloud auth application-default login
+
+# 2. Configure the backend
+aerolab config backend -t gcp -r us-central1 -o your-project-id
+
+# 3. Create a 2-node cluster
+aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
+  --instance e2-standard-4 \
+  --gcp-disk type=pd-ssd,size=20 \
+  --gcp-expire=8h
+
+# 4. Wait for it to come up, then use it
+aerolab aerospike is-stable -w
+aerolab attach aql -n mydc -- -c "show namespaces"
+
+# 5. Tear it down when done
+aerolab cluster destroy -n mydc --force
+```
+
+`--instance e2-standard-4` picks the instance type, `--gcp-disk type=pd-ssd,size=20` sets a
+20GB root disk, and `--gcp-expire=8h` auto-destroys the cluster after 8 hours so you don't
+forget it.
+
+## Configure the Backend
+
+```bash
+aerolab config backend -t gcp -r us-central1 -o your-project-id
+```
+
+Optional flags:
+
+| Flag | Effect |
+|------|--------|
+| `--inventory-cache` | Cache resource state locally — only if you're the sole user of the project. |
+| `--gcp-auto-enable-services` | Enable missing GCP APIs automatically, without prompting (required for CI/non-interactive use). |
+| `--gcp-nopublic-ip`, `--gcp-use-iap` | See [Gotchas](#gotchas) above. |
+| `--skip-pricing` | Skip cost/pricing lookups; needed under Workload Identity Federation, where the billing API rejects federated tokens. |
+| `-r` (comma-separated) | Enable multiple regions, e.g. `us-central1,us-east1,us-west1`. |
+
+Verify and check access:
+
+```bash
+aerolab config backend
+aerolab config backend -t gcp --check-access
+```
 
 ## GCP-Specific Configuration
 
-### List Firewall Rules
-
-View existing firewall rules:
+Firewall rules are managed with `config gcp`:
 
 ```bash
 aerolab config gcp list-firewall-rules
-```
-
-### Create Firewall Rules
-
-Create a firewall rule for Aerospike:
-
-```bash
 aerolab config gcp create-firewall-rules -n aerolab-fw -p 3000-3005
-```
-
-This creates a firewall rule allowing ports 3000-3005.
-
-### Lock Firewall Rules
-
-Lock a firewall rule to prevent deletion:
-
-```bash
 aerolab config gcp lock-firewall-rules -n aerolab-fw
-```
-
-### Delete Firewall Rules
-
-Delete a firewall rule:
-
-```bash
 aerolab config gcp delete-firewall-rules -n aerolab-fw
 ```
 
-## Creating Your First Cluster
+## Creating Clusters
 
-### Basic Cluster Creation
+Beyond the Quick Start example, common `cluster create` additions:
 
-Create a simple 2-node cluster:
+| Need | Flag(s) |
+|------|---------|
+| Specific zone | `--zone us-central1-a` |
+| Multiple disks | repeat `--gcp-disk type=pd-ssd,size=100,count=3` |
+| Different disk type | `--gcp-disk type=hyperdisk-balanced,size=100,iops=3060,throughput=155` |
+| Custom firewall rule | `--firewall aerolab-fw` |
+| Public IP (overrides backend default) | `--external-ip` |
+| Spot instances (cheaper) | `--gcp-spot-instance` |
+| Labels / tags | repeat `--label Key=Value` / `--tag name` |
+| Volume mount | `--gcp-vol-create --gcp-vol-mount myvolume:/mnt/data --gcp-vol-size 100` |
 
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  --instance e2-standard-4 \
-  --gcp-disk type=pd-ssd,size=20 \
-  --gcp-expire=8h
-```
+## Resource Expiry Automation
 
-This command:
-- Creates 2 nodes (`-c 2`)
-- Uses Ubuntu 24.04 (`-d ubuntu -i 24.04`)
-- Installs Aerospike version 8.x (`-v '8.*'`)
-- Uses `e2-standard-4` instance type (`--instance e2-standard-4`)
-- Creates 20GB PD-SSD root disk (`--gcp-disk type=pd-ssd,size=20`)
-- Sets expiry to 8 hours (`--gcp-expire=8h`)
-
-### Specify Zone
-
-Specify a zone for deployment:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  --instance e2-standard-4 \
-  --zone us-central1-a \
-  --gcp-disk type=pd-ssd,size=20 \
-  --gcp-expire=8h
-```
-
-### Multiple Disks
-
-Add multiple disks:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  --instance e2-standard-4 \
-  --gcp-disk type=pd-ssd,size=20 \
-  --gcp-disk type=pd-ssd,size=100,count=3 \
-  --gcp-expire=8h
-```
-
-This creates:
-- One 20GB PD-SSD root disk
-- Three 100GB PD-SSD data disks
-
-### Custom Disk Types
-
-Use different disk types:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  --instance e2-standard-4 \
-  --gcp-disk type=pd-ssd,size=20 \
-  --gcp-disk type=hyperdisk-balanced,size=100,iops=3060,throughput=155,count=2 \
-  --gcp-expire=8h
-```
-
-### Custom Firewall Rules
-
-Add custom firewall rules:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  --instance e2-standard-4 \
-  --firewall aerolab-fw \
-  --gcp-disk type=pd-ssd,size=20 \
-  --gcp-expire=8h
-```
-
-### Public IP
-
-Enable public IP access:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  --instance e2-standard-4 \
-  --external-ip \
-  --gcp-disk type=pd-ssd,size=20 \
-  --gcp-expire=8h
-```
-
-### Spot Instances
-
-Use spot instances for cost savings:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  --instance e2-standard-4 \
-  --gcp-spot-instance \
-  --gcp-disk type=pd-ssd,size=20 \
-  --gcp-expire=8h
-```
-
-### Custom Labels
-
-Add custom labels:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  --instance e2-standard-4 \
-  --label Environment=Development \
-  --label Team=Platform \
-  --gcp-disk type=pd-ssd,size=20 \
-  --gcp-expire=8h
-```
-
-### Custom Tags
-
-Add custom network tags:
-
-```bash
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  --instance e2-standard-4 \
-  --tag aerolab \
-  --tag production \
-  --gcp-disk type=pd-ssd,size=20 \
-  --gcp-expire=8h
-```
-
-## Resource Expiry Management
-
-### Install Expiry Automation
-
-Install automated resource expiry:
+Deploys a Cloud Function that auto-destroys expired resources (see
+[GCP Services](gcp-services.md) for the APIs it enables):
 
 ```bash
 aerolab config gcp expiry-install
-```
-
-This installs a Cloud Function that automatically cleans up expired resources.
-It requires several GCP services (Cloud Functions, Cloud Run, Cloud Build,
-Artifact Registry, Pub/Sub, Cloud Scheduler, Cloud Storage, and Cloud Logging).
-AeroLab enables any that are missing — prompting when interactive, or
-automatically when the backend was configured with `--gcp-auto-enable-services`.
-See [GCP Services (APIs) Required by AeroLab](gcp-services.md) for the full
-list and manual-enable commands.
-
-### List Expiry Rules
-
-View expiry rules:
-
-```bash
 aerolab config gcp expiry-list
-```
-
-### Set Expiry Run Frequency
-
-Configure how often expiry runs:
-
-```bash
-aerolab config gcp expiry-run-frequency -f 20
-```
-
-This sets expiry to run every 20 minutes.
-
-### Remove Expiry
-
-Remove expiry automation:
-
-```bash
+aerolab config gcp expiry-run-frequency -f 20   # minutes
 aerolab config gcp expiry-remove
 ```
 
-## Starting and Stopping Clusters
+## Next: Lifecycle, Attach, Files, Cleanup
 
-### Start Cluster
+Starting/stopping, controlling the Aerospike service, `attach` (shell/aql/asinfo/asadm),
+file upload/download, and cleanup are identical across every backend — see
+[Common Operations](common-operations.md). One GCP-specific note: stopping instances
+doesn't delete their persistent disks, so you're still billed until you `destroy` or let
+expiry run.
 
-Start all nodes in the cluster:
-
-```bash
-aerolab cluster start
-```
-
-### Stop Cluster
-
-Stop all nodes:
-
-```bash
-aerolab cluster stop
-```
-
-**Note**: Stopping instances in GCP doesn't delete them, but you'll still be charged for persistent disks. Use expiry or destroy to completely remove resources.
-
-## Managing Aerospike Service
-
-### Start Aerospike
-
-```bash
-aerolab aerospike start
-```
-
-### Stop Aerospike
-
-```bash
-aerolab aerospike stop
-```
-
-### Restart Aerospike
-
-```bash
-aerolab aerospike restart
-```
-
-### Check Status
-
-```bash
-aerolab aerospike status
-```
-
-### Wait for Cluster Stability
-
-```bash
-aerolab aerospike is-stable -w
-```
-
-## Connecting to Nodes
-
-### Shell Access
-
-```bash
-aerolab attach shell -n mydc -l 1
-```
-
-### Aerospike Tools
-
-```bash
-# AQL
-aerolab attach aql -n mydc -- -c "show namespaces"
-
-# asinfo
-aerolab attach asinfo -n mydc -- -v "cluster-stable"
-
-# asadm
-aerolab attach asadm -n mydc -- -e info
-```
-
-## File Operations
-
-### Upload Files
-
-```bash
-aerolab files upload -n mydc local-file.txt /tmp/remote-file.txt
-```
-
-### Download Files
-
-```bash
-aerolab files download -n mydc /tmp/remote-file.txt ./local-dir/
-```
-
-### Sync Files
-
-```bash
-aerolab files sync -n mydc -l 1 /tmp/file.txt
-```
-
-## GCP-Specific Features
-
-### Add Public IP Later
-
-Add public IP to existing cluster:
-
-```bash
-aerolab cluster add public-ip -n mydc
-```
-
-### Add Firewall Rules
-
-Add firewall rules to cluster:
-
-```bash
-aerolab cluster add firewall -n mydc -f aerolab-fw
-```
-
-### Volume Mounting
-
-Mount additional volumes:
-
-```bash
-# Create cluster with volume mount
-aerolab cluster create -c 2 -d ubuntu -i 24.04 -v '8.*' \
-  --instance e2-standard-4 \
-  --gcp-vol-create \
-  --gcp-vol-mount myvolume:/mnt/data \
-  --gcp-vol-size 100 \
-  --gcp-disk type=pd-ssd,size=20 \
-  --gcp-expire=8h
-```
-
-## Cleanup
-
-### Destroy a Cluster
-
-```bash
-aerolab cluster destroy -n mydc --force
-```
-
-### Clean Up All Resources
-
-```bash
-aerolab inventory delete-project-resources -f --expiry
-```
-
-## Common Workflows
-
-### Complete Workflow Example
-
-```bash
-# 1. Authenticate with GCP
-gcloud auth application-default login
-
-# 2. Configure backend
-aerolab config backend -t gcp -r us-central1 -o your-project-id
-
-# 3. Create firewall rule
-aerolab config gcp create-firewall-rules -n aerolab-fw -p 3000-3005
-
-# 4. Create cluster
-aerolab cluster create -c 3 -d ubuntu -i 24.04 -v '8.*' \
-  --instance e2-standard-4 \
-  --gcp-disk type=pd-ssd,size=20 \
-  --gcp-disk type=pd-ssd,size=100,count=3 \
-  --firewall aerolab-fw \
-  --gcp-expire=8h
-
-# 5. Start cluster
-aerolab cluster start
-
-# 6. Start Aerospike
-aerolab aerospike start
-
-# 7. Wait for stability
-aerolab aerospike is-stable -w
-
-# 8. Check status
-aerolab aerospike status
-
-# 9. Use the cluster
-aerolab attach aql -n mydc -- -c "show namespaces"
-
-# 10. Clean up
-aerolab cluster destroy -n mydc --force
-```
+Cluster-level extras: `aerolab cluster add public-ip -n mydc` and
+`aerolab cluster add firewall -n mydc -f aerolab-fw` add these after the fact.
 
 ## Troubleshooting
 
 ### Authentication Issues
 
-If you see authentication errors:
-
-1. **Application Default Credentials not found**: Ensure you've run `gcloud auth application-default login`:
-   ```bash
-   gcloud auth application-default login
-   ```
-   If you see the error "could not authenticate using application credentials", follow the instructions at: https://docs.cloud.google.com/docs/authentication/set-up-adc-local-dev-environment
-
-2. **Check authentication status**: Verify your gcloud authentication:
+1. **Application Default Credentials not found** — run
+   `gcloud auth application-default login`. If you see "could not authenticate using
+   application credentials", follow
+   https://docs.cloud.google.com/docs/authentication/set-up-adc-local-dev-environment.
+2. **Check status:**
    ```bash
    gcloud auth list
    gcloud config get-value project
    ```
+3. **Re-authenticate** if credentials expired: `gcloud auth application-default login`.
+4. **Check permissions** — your account needs Compute Engine permissions in the project.
 
-3. **Re-authenticate if needed**: If credentials have expired, run:
-   ```bash
-   gcloud auth application-default login
-   ```
-
-4. **Check permissions**: Ensure your user account has Compute Engine permissions in the GCP project
-
-### Project Issues
-
-If resources aren't found, verify the project ID:
+### Project / Region Issues
 
 ```bash
-aerolab config backend
-```
-
-### Region/Zone Issues
-
-Check available zones in your region:
-
-```bash
-gcloud compute zones list
+aerolab config backend               # verify project/region
+gcloud compute zones list            # available zones
 ```
 
 ### Instance Type Availability
-
-Check available instance types in your region:
 
 ```bash
 aerolab inventory instance-types
 ```
 
-### Network Issues
-
-If nodes can't communicate:
-
-1. Check firewall rules
-2. Verify VPC configuration
-3. Check network tags
-
 ### Quota Issues
 
-If you hit quota limits:
-
-1. Check quotas in GCP Console
-2. Request quota increases if needed
-3. Use smaller instance types or fewer nodes
+Check quotas in the GCP Console, request increases, or use smaller instances/fewer nodes.
 
 ## Next Steps
 
-- Explore [cluster management commands](commands/cluster.md)
-- Learn about [Aerospike daemon controls](commands/aerospike.md)
-- Check out [GCP-specific volume management](commands/volumes.md)
-- See [advanced features](commands/) for more options
-
+- [Common Operations](common-operations.md) - lifecycle, attach, files, cleanup
+- [Cluster management commands](../commands/cluster.md)
+- [GCP-specific volume management](../commands/volumes.md)
+- [GCP Services (APIs) Required by AeroLab](gcp-services.md)


### PR DESCRIPTION
Draft PR opened by **Tiger** (automated agent). Review before merging.

**Repo:** `aerolab`  
**Base:** `tiger/aerolab-1783696368-370129`

**Requested task:**
> make sure the getting started is not convoluted, is simple and easy to follow but at the same time it has all the required information. that includes getting started for docker, gcp, aws, generic one and the main readme. it must read "simple product" while covering all the gotchas like the iap and no publicip (and any others you find in config backend).

**Tiger's summary:**

Committed. Summary of what changed:

- **Root `README.md`**: tightened to a one-line pitch + working Docker quick start + doc links; dropped filler wording.
- **`docs/README.md`**: removed the ~70-line triplicate quick-start blocks (duplicated in each getting-started guide) and replaced with pointers.
- **`docs/getting-started/README.md`**: added explicit gotcha callouts for AWS (no IAP equivalent) and GCP (IAP/no-public-ip independence, Cloud NAT) right in the backend picker.
- **`docker.md` / `aws.md` / `gcp.md`**: each rewritten with the same shape — Prerequisites → **Gotchas** (new, prominent) → Quick Start → Configure Backend → backend-specific config → link to shared operations page → Troubleshooting. Cut docker.md from 410→~160 lines, aws.md from 579→~200, gcp.md from 700→~240, by moving the identical lifecycle/attach/files/cleanup commands (previously copy-pasted three times) into one new `docs/getting-started/common-operations.md`.
- Verified all inbound anchor links (`aws.md#optional-disable-public-ips`, `gcp.md#optional-route-sshsftp-through-iap`, `gcp.md#authentication-issues`) still resolve.

Gotchas now documented, confirmed against the actual Go source (not just prior docs):
- AWS `--aws-nopublic-ip` has no SSM/IAP/tunnel fallback — you must already have private network access.
- GCP `--gcp-nopublic-ip` and `--gcp-use-iap` are independent; IAP needs a manually-granted IAM role and, for custom firewalls, a manually-added `35.235.240.0/20` rule.
- GCP Cloud NAT check runs before every `cluster create` when there's no public IP, but silently fails open if the check API call itself errors.
- Several `config backend` boolean flags (`--aws-nopublic-ip`, `--gcp-nopublic-ip`, `--gcp-use-iap`, `--gcp-auto-enable-services`, `--skip-pricing`) are not sticky — they must be repeated on every invocation or they silently reset.
