### PR TITLE
[tiger] we should parse the template config if provided by user, and

### DIFF
--- a/cli/cmd/v1/cmdClusterCreate.go
+++ b/cli/cmd/v1/cmdClusterCreate.go
@@ -51,6 +51,11 @@ type ClusterCreateCmd struct {
 	CapacityRetries    int           `long:"capacity-retries" description:"Maximum retries for capacity errors (AWS/GCP only)" default:"0" simplemode:"false"`
 	CapacityRetrySleep time.Duration `long:"capacity-retry-sleep" description:"Sleep duration between capacity retries" default:"60s" simplemode:"false"`
 	Help               HelpCmd       `command:"help" subcommands-optional:"true" description:"Print help"`
+	// customConfig holds an in-memory, augmented copy of the custom aerospike.conf
+	// (see checkCustomConfigBasics) when the user opted in to having aerolab add
+	// missing basic items. When set, it is installed in place of re-reading
+	// CustomConfigFilePath, leaving the user's original file untouched.
+	customConfig []byte
 }
 
 type ClusterCreateCmdAws struct {
@@ -488,7 +493,12 @@ func (c *ClusterCreateCmd) CreateCluster(system *System, inventory *backends.Inv
 	}
 	containerServicePort := "3000"
 	if c.CustomConfigFilePath != "" && system.Opts.Config.Backend.Type == "docker" {
-		if confData, err := os.ReadFile(string(c.CustomConfigFilePath)); err == nil {
+		confData := c.customConfig
+		var readErr error
+		if len(confData) == 0 {
+			confData, readErr = os.ReadFile(string(c.CustomConfigFilePath))
+		}
+		if readErr == nil {
 			if cfg, err := aeroconf.Parse(bytes.NewReader(confData)); err == nil {
 				if cfg.Type("network") == aeroconf.ValueStanza {
 					ns := cfg.Stanza("network")
@@ -749,10 +759,14 @@ func (c *ClusterCreateCmd) CreateCluster(system *System, inventory *backends.Inv
 		// read existing config
 		var conf []byte
 		if c.CustomConfigFilePath != "" && i.isNew {
-			conf, err = os.ReadFile(string(c.CustomConfigFilePath))
-			if err != nil {
-				errs = append(errs, err)
-				return
+			if len(c.customConfig) > 0 {
+				conf = c.customConfig
+			} else {
+				conf, err = os.ReadFile(string(c.CustomConfigFilePath))
+				if err != nil {
+					errs = append(errs, err)
+					return
+				}
 			}
 		} else {
 			var buf bytes.Buffer
@@ -1131,6 +1145,9 @@ func (c *ClusterCreateCmd) SanityChecks(system *System, inventory *backends.Inve
 		if _, err := os.Stat(string(c.CustomConfigFilePath)); os.IsNotExist(err) {
 			return errors.New("custom-config-file path " + string(c.CustomConfigFilePath) + " does not exist")
 		}
+		if err := c.checkCustomConfigBasics(logger); err != nil {
+			return err
+		}
 	}
 
 	if c.CustomToolsFilePath != "" {
@@ -1153,6 +1170,222 @@ func (c *ClusterCreateCmd) SanityChecks(system *System, inventory *backends.Inve
 		return err
 	}
 	return nil
+}
+
+// checkCustomConfigBasics parses a user-supplied aerospike.conf and warns about
+// any "basic" items that aerospike needs to start but that aerolab does not
+// reliably synthesise when a custom config is provided (logging, the service
+// port, heartbeat, fabric and at least one namespace). When running
+// interactively it offers to inject sane defaults for the missing items; if the
+// user agrees, the augmented config is kept in memory (c.customConfig) and
+// installed in place of the original file, which is left untouched. It also
+// warns when network.service.port is set to something other than the default
+// 3000, since aerolab's roster/asinfo tooling runs bare asinfo against 3000.
+func (c *ClusterCreateCmd) checkCustomConfigBasics(logger *logger.Logger) error {
+	if c.CustomConfigFilePath == "" {
+		return nil
+	}
+	confData, err := os.ReadFile(string(c.CustomConfigFilePath))
+	if err != nil {
+		return fmt.Errorf("failed to read custom config file %s: %s", c.CustomConfigFilePath, err)
+	}
+	report, err := inspectCustomConfig(confData)
+	if err != nil {
+		return fmt.Errorf("failed to parse custom config file %s: %s", c.CustomConfigFilePath, err)
+	}
+
+	// warn when the service port is not the default 3000: aerolab's roster and
+	// stability tooling run bare asinfo which assumes 127.0.0.1:3000.
+	if report.nonDefaultPort != "" {
+		logger.Warn("custom config sets network.service.port to %s (not the default 3000); aerolab commands such as `roster apply`, `roster show` and `aerospike-is-stable` run bare asinfo against 127.0.0.1:3000 and will fail to connect to this cluster", report.nonDefaultPort)
+	}
+
+	// aerolab does not fabricate a namespace when a custom config is supplied.
+	if !report.hasNamespace {
+		logger.Warn("custom config %s does not define any namespace stanza; aerospike will not start without at least one namespace (aerolab will not add one for you when a custom config is provided)", c.CustomConfigFilePath)
+	}
+
+	if len(report.missing) == 0 {
+		return nil
+	}
+
+	logger.Warn("custom config %s is missing basic items that aerospike/aerolab expect: %s", c.CustomConfigFilePath, strings.Join(report.missing, ", "))
+
+	if !IsInteractive() {
+		logger.Warn("re-run interactively to have aerolab add these defaults for you, or add them to your config manually before creating the cluster")
+		return nil
+	}
+
+	fmt.Printf("Add the missing basic items to the config aerolab will install (%s)? [y/N]: ", strings.Join(report.missing, ", "))
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	if answer != "y" && answer != "yes" {
+		logger.Info("leaving custom config unchanged")
+		return nil
+	}
+
+	c.customConfig = report.augmented
+	logger.Info("added default values for: %s (installing an augmented in-memory copy; your original file %s is left untouched)", strings.Join(report.missing, ", "), c.CustomConfigFilePath)
+	return nil
+}
+
+// customConfigReport is the result of inspecting a user-supplied aerospike.conf
+// for the basic items aerospike needs to start but that aerolab does not
+// reliably synthesise when a custom config is provided.
+type customConfigReport struct {
+	missing        []string // labels of missing basic items, in a stable order
+	augmented      []byte   // the input config with defaults injected for every missing item
+	hasNamespace   bool     // whether at least one namespace stanza is defined
+	nonDefaultPort string   // network.service.port when set to something other than 3000, else ""
+}
+
+// inspectCustomConfig parses confData, determines which basic items are missing
+// and builds an augmented copy with sane defaults injected for each. It is pure
+// (no IO) so the detection and augmentation can be unit-tested.
+func inspectCustomConfig(confData []byte) (customConfigReport, error) {
+	var report customConfigReport
+	cfg, err := aeroconf.Parse(bytes.NewReader(confData))
+	if err != nil {
+		return report, err
+	}
+
+	// stanza walks a stanza path, returning nil if any segment is missing.
+	stanza := func(parts ...string) aeroconf.Stanza {
+		s := cfg
+		for _, p := range parts {
+			if s.Type(p) != aeroconf.ValueStanza {
+				return nil
+			}
+			s = s.Stanza(p)
+		}
+		return s
+	}
+	// hasVal reports whether a (possibly nil) stanza has a non-empty value key.
+	hasVal := func(s aeroconf.Stanza, key string) bool {
+		if s == nil {
+			return false
+		}
+		vals, err := s.GetValues(key)
+		return err == nil && len(vals) > 0 && vals[0] != nil
+	}
+	// ensureStanza vivifies a stanza path, returning the leaf stanza.
+	ensureStanza := func(parts ...string) (aeroconf.Stanza, error) {
+		s := cfg
+		for _, p := range parts {
+			if s.Type(p) != aeroconf.ValueStanza {
+				if err := s.NewStanza(p); err != nil {
+					return nil, err
+				}
+			}
+			s = s.Stanza(p)
+		}
+		return s, nil
+	}
+
+	for _, k := range cfg.ListKeys() {
+		if strings.HasPrefix(k, "namespace ") && cfg.Type(k) == aeroconf.ValueStanza {
+			report.hasNamespace = true
+			break
+		}
+	}
+	if svc := stanza("network", "service"); svc != nil {
+		if vals, err := svc.GetValues("port"); err == nil && len(vals) > 0 && vals[0] != nil {
+			if p := strings.TrimSpace(*vals[0]); p != "" && p != "3000" {
+				report.nonDefaultPort = p
+			}
+		}
+	}
+
+	// each fix describes one missing basic item and how to inject a default.
+	type fix struct {
+		label   string
+		missing bool
+		apply   func() error
+	}
+	fixes := []fix{
+		{
+			label:   "service (proto-fd-max 15000)",
+			missing: stanza("service") == nil,
+			apply: func() error {
+				s, err := ensureStanza("service")
+				if err != nil {
+					return err
+				}
+				return s.SetValue("proto-fd-max", "15000")
+			},
+		},
+		{
+			label:   "logging (file /var/log/aerospike.log)",
+			missing: stanza("logging") == nil,
+			apply: func() error {
+				s, err := ensureStanza("logging", "file /var/log/aerospike.log")
+				if err != nil {
+					return err
+				}
+				return s.SetValue("context", "any info")
+			},
+		},
+		{
+			label:   "network.service.port (3000)",
+			missing: !hasVal(stanza("network", "service"), "port"),
+			apply: func() error {
+				s, err := ensureStanza("network", "service")
+				if err != nil {
+					return err
+				}
+				return s.SetValue("port", "3000")
+			},
+		},
+		{
+			label:   "network.heartbeat (mode mesh, port 3002)",
+			missing: stanza("network", "heartbeat") == nil || !hasVal(stanza("network", "heartbeat"), "mode") || !hasVal(stanza("network", "heartbeat"), "port"),
+			apply: func() error {
+				s, err := ensureStanza("network", "heartbeat")
+				if err != nil {
+					return err
+				}
+				// stable order so serialised output is deterministic
+				for _, kv := range [][2]string{{"mode", "mesh"}, {"port", "3002"}, {"interval", "150"}, {"timeout", "10"}} {
+					if !hasVal(s, kv[0]) {
+						if err := s.SetValue(kv[0], kv[1]); err != nil {
+							return err
+						}
+					}
+				}
+				return nil
+			},
+		},
+		{
+			label:   "network.fabric.port (3001)",
+			missing: !hasVal(stanza("network", "fabric"), "port"),
+			apply: func() error {
+				s, err := ensureStanza("network", "fabric")
+				if err != nil {
+					return err
+				}
+				return s.SetValue("port", "3001")
+			},
+		},
+	}
+
+	for _, f := range fixes {
+		if !f.missing {
+			continue
+		}
+		report.missing = append(report.missing, f.label)
+		if err := f.apply(); err != nil {
+			return report, fmt.Errorf("failed to add default for %s: %s", f.label, err)
+		}
+	}
+	if len(report.missing) > 0 {
+		var buf bytes.Buffer
+		if err := cfg.Write(&buf, "", "    ", true); err != nil {
+			return report, fmt.Errorf("failed to serialise augmented custom config: %s", err)
+		}
+		report.augmented = buf.Bytes()
+	}
+	return report, nil
 }
 
 func (c *ClusterCreateCmd) FeaturesFilePathResolve(system *System, inventory *backends.Inventory, logger *logger.Logger) (string, error) {

--- a/cli/cmd/v1/cmdClusterCreate_customconf_test.go
+++ b/cli/cmd/v1/cmdClusterCreate_customconf_test.go
@@ -1,0 +1,203 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	aeroconf "github.com/rglonek/aerospike-config-file-parser"
+	flags "github.com/rglonek/go-flags"
+	"github.com/rglonek/logger"
+)
+
+// writeTempConf writes conf to a temp file and returns its path.
+func writeTempConf(t *testing.T, conf string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "aerospike.conf")
+	if err := os.WriteFile(p, []byte(conf), 0644); err != nil {
+		t.Fatalf("write temp conf: %v", err)
+	}
+	return p
+}
+
+func confHasVal(t *testing.T, cfg aeroconf.Stanza, parts []string, key string) bool {
+	t.Helper()
+	s := cfg
+	for _, p := range parts {
+		if s.Type(p) != aeroconf.ValueStanza {
+			return false
+		}
+		s = s.Stanza(p)
+	}
+	vals, err := s.GetValues(key)
+	return err == nil && len(vals) > 0 && vals[0] != nil
+}
+
+// TestInspectCustomConfig_AugmentsMissingBasics verifies that a namespace-only
+// config gets every missing basic item injected and that the result parses back
+// into a complete, self-consistent config.
+func TestInspectCustomConfig_AugmentsMissingBasics(t *testing.T) {
+	const conf = `namespace test {
+    replication-factor 1
+    strong-consistency true
+    storage-engine device {
+        file /opt/aerospike/data/test.dat
+        filesize 4G
+    }
+}
+`
+	report, err := inspectCustomConfig([]byte(conf))
+	if err != nil {
+		t.Fatalf("inspectCustomConfig: %v", err)
+	}
+	if !report.hasNamespace {
+		t.Errorf("expected hasNamespace=true")
+	}
+	if report.nonDefaultPort != "" {
+		t.Errorf("expected no nonDefaultPort, got %q", report.nonDefaultPort)
+	}
+	wantMissing := []string{
+		"service (proto-fd-max 15000)",
+		"logging (file /var/log/aerospike.log)",
+		"network.service.port (3000)",
+		"network.heartbeat (mode mesh, port 3002)",
+		"network.fabric.port (3001)",
+	}
+	if len(report.missing) != len(wantMissing) {
+		t.Fatalf("missing mismatch:\n got %v\nwant %v", report.missing, wantMissing)
+	}
+	for i := range wantMissing {
+		if report.missing[i] != wantMissing[i] {
+			t.Fatalf("missing[%d] = %q, want %q", i, report.missing[i], wantMissing[i])
+		}
+	}
+
+	// the augmented config must parse and contain all the injected basics
+	cfg, err := aeroconf.Parse(bytes.NewReader(report.augmented))
+	if err != nil {
+		t.Fatalf("augmented config does not parse: %v\n%s", err, report.augmented)
+	}
+	if !confHasVal(t, cfg, []string{"service"}, "proto-fd-max") {
+		t.Error("augmented config missing service.proto-fd-max")
+	}
+	if cfg.Type("logging") != aeroconf.ValueStanza {
+		t.Error("augmented config missing logging stanza")
+	}
+	if !confHasVal(t, cfg, []string{"network", "service"}, "port") {
+		t.Error("augmented config missing network.service.port")
+	}
+	if !confHasVal(t, cfg, []string{"network", "heartbeat"}, "mode") || !confHasVal(t, cfg, []string{"network", "heartbeat"}, "port") {
+		t.Error("augmented config missing network.heartbeat mode/port")
+	}
+	if !confHasVal(t, cfg, []string{"network", "fabric"}, "port") {
+		t.Error("augmented config missing network.fabric.port")
+	}
+	// the original namespace must survive augmentation
+	if cfg.Type("namespace test") != aeroconf.ValueStanza {
+		t.Error("augmented config dropped the original namespace")
+	}
+	// the injected service port must be the default 3000
+	if vals, _ := cfg.Stanza("network").Stanza("service").GetValues("port"); len(vals) == 0 || vals[0] == nil || *vals[0] != "3000" {
+		t.Errorf("expected injected service port 3000, got %v", vals)
+	}
+}
+
+// TestInspectCustomConfig_CompleteConfig verifies a config with all basics
+// yields no missing items and no augmentation.
+func TestInspectCustomConfig_CompleteConfig(t *testing.T) {
+	const conf = `service {
+    proto-fd-max 15000
+}
+logging {
+    file /var/log/aerospike.log {
+        context any info
+    }
+}
+network {
+    service {
+        port 3000
+    }
+    heartbeat {
+        mode mesh
+        port 3002
+    }
+    fabric {
+        port 3001
+    }
+}
+namespace test {
+    replication-factor 1
+    storage-engine memory {
+        data-size 1G
+    }
+}
+`
+	report, err := inspectCustomConfig([]byte(conf))
+	if err != nil {
+		t.Fatalf("inspectCustomConfig: %v", err)
+	}
+	if len(report.missing) != 0 {
+		t.Errorf("expected no missing items, got %v", report.missing)
+	}
+	if report.augmented != nil {
+		t.Errorf("expected no augmentation for a complete config")
+	}
+	if !report.hasNamespace {
+		t.Errorf("expected hasNamespace=true")
+	}
+}
+
+// TestInspectCustomConfig_NonDefaultPort verifies the non-3000 port is surfaced
+// and not mistaken for a missing port.
+func TestInspectCustomConfig_NonDefaultPort(t *testing.T) {
+	const conf = `network {
+    service {
+        port 3100
+    }
+}
+namespace test {
+    replication-factor 1
+    storage-engine memory {
+        data-size 1G
+    }
+}
+`
+	report, err := inspectCustomConfig([]byte(conf))
+	if err != nil {
+		t.Fatalf("inspectCustomConfig: %v", err)
+	}
+	if report.nonDefaultPort != "3100" {
+		t.Errorf("expected nonDefaultPort=3100, got %q", report.nonDefaultPort)
+	}
+	for _, m := range report.missing {
+		if m == "network.service.port (3000)" {
+			t.Error("service.port present but reported missing")
+		}
+	}
+}
+
+// TestCheckCustomConfigBasics_NonInteractive verifies that, when not running
+// interactively, checkCustomConfigBasics only warns (never errors) and never
+// mutates the config in-memory.
+func TestCheckCustomConfigBasics_NonInteractive(t *testing.T) {
+	// IsInteractive() is false under `go test`, so this exercises the
+	// warn-only path.
+	c := &ClusterCreateCmd{}
+	c.CustomConfigFilePath = flags.Filename(writeTempConf(t, "namespace test {\n    replication-factor 1\n    storage-engine memory {\n        data-size 1G\n    }\n}\n"))
+	if err := c.checkCustomConfigBasics(logger.NewLogger()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(c.customConfig) != 0 {
+		t.Fatalf("customConfig should stay empty in non-interactive mode, got %d bytes", len(c.customConfig))
+	}
+}
+
+// TestCheckCustomConfigBasics_NoCustomConfig verifies the no-op path.
+func TestCheckCustomConfigBasics_NoCustomConfig(t *testing.T) {
+	c := &ClusterCreateCmd{}
+	if err := c.checkCustomConfigBasics(logger.NewLogger()); err != nil {
+		t.Fatalf("unexpected error with no custom config: %v", err)
+	}
+}


### PR DESCRIPTION
Draft PR opened by **Tiger** (automated agent). Review before merging.

**Repo:** `aerolab`  
**Base:** `v8.0.0`

**Requested task:**
> we should parse the template config if provided by user, and see if it misses any of the basic items needed. if so, we should warn about it. we should also ask the user (if IsInteractive() is true) if they want us to add the missing items, and add if so. we should also check if the default service port is 3000, and if it is not, do another warn.

**Tiger's summary:**

Done. Here's what I implemented and committed.

## What the change does

When you pass a custom `aerospike.conf` via `-o`/`--customconf`, `cluster create` now parses it during sanity checks (before any node is created) and:

1. **Warns about missing basic items** — checks for `service`, `logging`, `network.service.port`, `network.heartbeat` (mode/port), `network.fabric.port`, and at least one `namespace` stanza. Anything missing is listed in a single warning. This is exactly the class of gap that produced your `CRITICAL (config): no service ports configured` — aerolab never synthesizes `network.service.port`, so omitting it silently broke asd startup.

2. **Offers to fix it when interactive** — if `IsInteractive()` is true and items are missing, it prompts `Add the missing basic items ...? [y/N]`. On "yes", it injects sane defaults (service.port 3000, fabric 3001, heartbeat mesh/3002/150/10, file logging, proto-fd-max 15000) into an **in-memory augmented copy** that gets installed instead — your original file on disk is left untouched. Non-interactive runs just warn and tell you to re-run interactively or fix it manually.

3. **Warns on a non-3000 service port** — if `network.service.port` is set to something other than 3000 (like the 3100 in your earlier config), it warns that `roster apply`, `roster show`, and `aerospike-is-stable` run bare `asinfo` against `127.0.0.1:3000` and will fail — which is the root cause of your original `roster apply` error.

The namespace stanza is deliberately warn-only (never auto-injected) — aerolab shouldn't fabricate a namespace when the whole point of your custom conf is to define it.

## Implementation notes
- Detection + augmentation is factored into a pure `inspectCustomConfig()` helper (no IO), so it's unit-testable; the method `checkCustomConfigBasics` is just the warn/prompt wrapper.
- Both existing read sites that consume the custom config (the Docker port-extraction at `cmdClusterCreate.go:493` and the config-install at `:759`) now prefer the augmented in-memory copy when present.
- Added `cmdClusterCreate_customconf_test.go` covering augmentation of a namespace-only config, a complete config (no-op), non-default port detection, and the non-interactive path.

Build, `go vet`, and the full `./cli/...` test suite all pass. Committed on your branch as `6d5eb7d9`.

Two things worth flagging for you as the reviewer:
- This does **not** fix the underlying `roster apply`/`asinfo` port bug (those commands still hardcode port 3000) — it only warns you about it. If you want, I can follow up by making those commands read the node's actual `network.service.port` and pass `-p`. This PR intentionally scopes to what you asked for.
- The injected defaults assume the Docker workflow (mesh heartbeat, file logging). They're sensible on any backend, but the warnings/fixes fire for all backends since the missing basics matter everywhere.
