### PR TITLE
[tiger] Add aerospike-tools bundle to JFrog template creation

### DIFF
--- a/cli/cmd/v1/cmdTemplateCreate.go
+++ b/cli/cmd/v1/cmdTemplateCreate.go
@@ -480,6 +480,24 @@ func (c *TemplateCreateCmd) CreateTemplate(system *System, inventory *backends.I
 				cli.Close()
 				return "", fmt.Errorf("could not upload JFrog package: %s", err)
 			}
+			if jfrogPkg.toolsPkgRemotePath != "" {
+				logger.Info("Uploading JFrog tools package %s to %s:%s", jfrogPkg.toolsPkgLocalPath, conf.Host, jfrogPkg.toolsPkgRemotePath)
+				tf, err := os.Open(jfrogPkg.toolsPkgLocalPath)
+				if err != nil {
+					cli.Close()
+					return "", fmt.Errorf("could not open cached JFrog tools package: %s", err)
+				}
+				err = cli.WriteFile(true, &sshexec.FileWriter{
+					DestPath:    jfrogPkg.toolsPkgRemotePath,
+					Source:      tf,
+					Permissions: 0644,
+				})
+				tf.Close()
+				if err != nil {
+					cli.Close()
+					return "", fmt.Errorf("could not upload JFrog tools package: %s", err)
+				}
+			}
 		}
 		err = cli.WriteFile(true, &sshexec.FileWriter{
 			DestPath:    "/opt/aerolab/scripts/template-install.sh",

--- a/cli/cmd/v1/cmdTemplateCreate_jfrog.go
+++ b/cli/cmd/v1/cmdTemplateCreate_jfrog.go
@@ -14,12 +14,14 @@ import (
 // resolved install script, plus the local package file that has to be
 // SFTP-uploaded to each instance before the script runs.
 type jfrogPlan struct {
-	script        []byte
-	pkgLocalPath  string // path on operator's laptop
-	pkgRemotePath string // path on target instance
-	version       string // canonical build number (with -artifacts suffix)
-	edition       string // community | enterprise | federal
-	osVersion     string // never "latest"; resolved before return
+	script             []byte
+	pkgLocalPath       string // path on operator's laptop
+	pkgRemotePath      string // path on target instance
+	toolsPkgLocalPath  string // aerospike-tools .tgz on operator's laptop ("" if not found)
+	toolsPkgRemotePath string // aerospike-tools .tgz path on target instance ("" if not found)
+	version            string // canonical build number (with -artifacts suffix)
+	edition            string // community | enterprise | federal
+	osVersion          string // never "latest"; resolved before return
 }
 
 // resolveJFrogPlan does the JFrog-specific equivalent of
@@ -86,6 +88,34 @@ func resolveJFrogPlan(system *System, log *logger.Logger, aerospikeVersion, dist
 	if err != nil {
 		return nil, err
 	}
+
+	// The JFrog server .deb/.rpm installs only the server (asd); it does not
+	// bundle the tools the public .tgz flow gets via asinstall. Without
+	// asinfo/asadm/aql, aerolab commands such as `roster apply`, `roster show`
+	// and `aerospike-is-stable` fail on the resulting cluster. So locate,
+	// download and install the matching aerospike-tools .tgz from the same
+	// build, keeping JFrog templates interchangeable with the public ones.
+	var toolsLocal, toolsRemote string
+	if toolsMatch := files.MatchTools(jfrog.MatchCriteria{
+		OSName:    osName,
+		OSVersion: distroVersion,
+		Arch:      jfArch,
+	}); toolsMatch != nil {
+		log.Info("Selected tools artifact: %s/%s/%s (%d bytes)", toolsMatch.Repo, toolsMatch.Path, toolsMatch.Name, toolsMatch.Size)
+		toolsLocal, err = cfg.Download(context.Background(), toolsMatch, cacheDir)
+		if err != nil {
+			return nil, fmt.Errorf("could not download aerospike-tools package: %w", err)
+		}
+		toolsScript, err := jfrog.ToolsInstallScript(toolsMatch, false)
+		if err != nil {
+			return nil, fmt.Errorf("could not build aerospike-tools install script: %w", err)
+		}
+		pkgScript = append(pkgScript, toolsScript...)
+		toolsRemote = jfrog.RemotePackagePath(toolsMatch)
+	} else {
+		log.Warn("JFrog build has no matching aerospike-tools package for %s/%s/%s; asinfo/asadm/aql will be missing and commands such as `roster apply`, `roster show` and `aerospike-is-stable` will fail on this cluster", osName, distroVersion, jfArch)
+	}
+
 	// Wrap with the same "basic tools" optional dependency set the
 	// public flow uses so the resulting templates are interchangeable.
 	wrapped, err := installers.GetInstallScript(templateOptionalDeps(debug), pkgScript)
@@ -94,12 +124,14 @@ func resolveJFrogPlan(system *System, log *logger.Logger, aerospikeVersion, dist
 	}
 
 	return &jfrogPlan{
-		script:        wrapped,
-		pkgLocalPath:  local,
-		pkgRemotePath: jfrog.RemotePackagePath(match),
-		version:       build.Number,
-		edition:       edition,
-		osVersion:     distroVersion,
+		script:             wrapped,
+		pkgLocalPath:       local,
+		pkgRemotePath:      jfrog.RemotePackagePath(match),
+		toolsPkgLocalPath:  toolsLocal,
+		toolsPkgRemotePath: toolsRemote,
+		version:            build.Number,
+		edition:            edition,
+		osVersion:          distroVersion,
 	}, nil
 }
 

--- a/cli/cmd/v1/cmdTemplateCreate_jfrog.go
+++ b/cli/cmd/v1/cmdTemplateCreate_jfrog.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/aerospike/aerolab/pkg/utils/installers"
+	"github.com/aerospike/aerolab/pkg/utils/installers/aerospike"
 	"github.com/aerospike/aerolab/pkg/utils/installers/aerospike/jfrog"
 	"github.com/rglonek/logger"
 )
@@ -92,28 +94,14 @@ func resolveJFrogPlan(system *System, log *logger.Logger, aerospikeVersion, dist
 	// The JFrog server .deb/.rpm installs only the server (asd); it does not
 	// bundle the tools the public .tgz flow gets via asinstall. Without
 	// asinfo/asadm/aql, aerolab commands such as `roster apply`, `roster show`
-	// and `aerospike-is-stable` fail on the resulting cluster. So locate,
-	// download and install the matching aerospike-tools .tgz from the same
-	// build, keeping JFrog templates interchangeable with the public ones.
-	var toolsLocal, toolsRemote string
-	if toolsMatch := files.MatchTools(jfrog.MatchCriteria{
-		OSName:    osName,
-		OSVersion: distroVersion,
-		Arch:      jfArch,
-	}); toolsMatch != nil {
-		log.Info("Selected tools artifact: %s/%s/%s (%d bytes)", toolsMatch.Repo, toolsMatch.Path, toolsMatch.Name, toolsMatch.Size)
-		toolsLocal, err = cfg.Download(context.Background(), toolsMatch, cacheDir)
-		if err != nil {
-			return nil, fmt.Errorf("could not download aerospike-tools package: %w", err)
-		}
-		toolsScript, err := jfrog.ToolsInstallScript(toolsMatch, false)
-		if err != nil {
-			return nil, fmt.Errorf("could not build aerospike-tools install script: %w", err)
-		}
+	// and `aerospike-is-stable` fail on the resulting cluster. Resolve a
+	// tools install (preferring this build, then latest on JFrog, then the
+	// public channel) so JFrog templates stay interchangeable with public ones.
+	toolsScript, toolsLocal, toolsRemote, err := resolveJFrogTools(cfg, files, cacheDir, osName, distroVersion, jfArch, debug, log)
+	if err != nil {
+		log.Warn("could not provision aerospike-tools from any source (this build, JFrog, or the public channel): %s; the cluster will lack asinfo/asadm/aql and commands such as `roster apply`, `roster show` and `aerospike-is-stable` will fail", err)
+	} else if len(toolsScript) > 0 {
 		pkgScript = append(pkgScript, toolsScript...)
-		toolsRemote = jfrog.RemotePackagePath(toolsMatch)
-	} else {
-		log.Warn("JFrog build has no matching aerospike-tools package for %s/%s/%s; asinfo/asadm/aql will be missing and commands such as `roster apply`, `roster show` and `aerospike-is-stable` will fail on this cluster", osName, distroVersion, jfArch)
 	}
 
 	// Wrap with the same "basic tools" optional dependency set the
@@ -133,6 +121,94 @@ func resolveJFrogPlan(system *System, log *logger.Logger, aerospikeVersion, dist
 		edition:            edition,
 		osVersion:          distroVersion,
 	}, nil
+}
+
+// resolveJFrogTools builds the aerospike-tools install portion of a JFrog
+// template, trying the sources below in order of preference so a cluster
+// always ends up with asinfo/asadm/aql:
+//
+//  1. the aerospike-tools .tgz attached to THIS build (same version);
+//  2. the latest aerospike-tools .tgz anywhere on the JFrog instance;
+//  3. the latest aerospike-tools from the public Aerospike channel.
+//
+// Sources 1 and 2 are JFrog artifacts the node may not be able to reach, so
+// they are pre-downloaded to the operator's cache and returned via
+// (localPath, remotePath) for the caller to SFTP-upload. Source 3 is fetched
+// by the node itself at install time, so it returns empty paths. It returns
+// an error only when all three sources fail.
+func resolveJFrogTools(cfg *jfrog.Config, buildFiles jfrog.Files, cacheDir, osName, distroVersion, jfArch string, debug bool, log *logger.Logger) (script []byte, localPath, remotePath string, err error) {
+	// 1: the tools shipped with this exact build.
+	if m := buildFiles.MatchTools(jfrog.MatchCriteria{OSName: osName, OSVersion: distroVersion, Arch: jfArch}); m != nil {
+		log.Info("Using aerospike-tools from this build: %s (%d bytes)", m.Name, m.Size)
+		return downloadJFrogTools(cfg, m, cacheDir)
+	}
+
+	// 2: the latest tools anywhere on JFrog.
+	log.Warn("this build has no matching aerospike-tools package for %s/%s/%s; searching JFrog for the latest tools", osName, distroVersion, jfArch)
+	if m, e := cfg.LatestToolsFile(context.Background(), osName, distroVersion, jfArch); e != nil {
+		log.Warn("could not query JFrog for the latest aerospike-tools: %s", e)
+	} else if m != nil {
+		log.Info("Using latest aerospike-tools from JFrog: %s (%d bytes)", m.Name, m.Size)
+		return downloadJFrogTools(cfg, m, cacheDir)
+	}
+
+	// 3: the latest tools from the public download channel (node fetches it).
+	log.Warn("no aerospike-tools found on JFrog for %s/%s/%s; falling back to the public Aerospike download channel", osName, distroVersion, jfArch)
+	s, e := publicToolsInstallScript(osName, distroVersion, jfArch, debug)
+	if e != nil {
+		return nil, "", "", e
+	}
+	log.Info("Using latest aerospike-tools from the public Aerospike channel")
+	return s, "", "", nil
+}
+
+// downloadJFrogTools caches a JFrog tools artifact locally and returns its
+// install-script snippet plus the local/remote package paths for upload.
+func downloadJFrogTools(cfg *jfrog.Config, m *jfrog.File, cacheDir string) (script []byte, localPath, remotePath string, err error) {
+	localPath, err = cfg.Download(context.Background(), m, cacheDir)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("could not download aerospike-tools package: %w", err)
+	}
+	script, err = jfrog.ToolsInstallScript(m, false)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("could not build aerospike-tools install script: %w", err)
+	}
+	return script, localPath, jfrog.RemotePackagePath(m), nil
+}
+
+// publicToolsInstallScript resolves the latest aerospike-tools on the public
+// download channel and returns an install script that downloads and installs
+// it on the target node itself (no operator-side pre-download).
+func publicToolsInstallScript(osName, distroVersion, jfArch string, debug bool) ([]byte, error) {
+	products, err := aerospike.GetProducts(30 * time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("could not list public products: %w", err)
+	}
+	prod := products.WithName("aerospike-tools")
+	if len(prod) == 0 {
+		return nil, fmt.Errorf("no aerospike-tools product found on the public channel")
+	}
+	versions, err := aerospike.GetVersions(30*time.Second, prod[0])
+	if err != nil {
+		return nil, fmt.Errorf("could not list public aerospike-tools versions: %w", err)
+	}
+	version := versions.Latest()
+	if version == nil {
+		return nil, fmt.Errorf("no public aerospike-tools versions found")
+	}
+	files, err := aerospike.GetFiles(30*time.Second, *version)
+	if err != nil {
+		return nil, fmt.Errorf("could not list public aerospike-tools files: %w", err)
+	}
+	arch := aerospike.ArchitectureTypeX86_64
+	if jfArch == "aarch64" {
+		arch = aerospike.ArchitectureTypeAARCH64
+	}
+	script, err := files.GetInstallScript(arch, aerospike.OSName(osName), distroVersion, debug, true, true, true)
+	if err != nil {
+		return nil, fmt.Errorf("no public aerospike-tools package for %s/%s/%s: %w", osName, distroVersion, jfArch, err)
+	}
+	return script, nil
 }
 
 // jfrogResolveLight returns the canonical build number and edition

--- a/pkg/utils/installers/aerospike/jfrog/files.go
+++ b/pkg/utils/installers/aerospike/jfrog/files.go
@@ -1,6 +1,8 @@
 package jfrog
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -100,6 +102,71 @@ func (fs Files) MatchTools(c MatchCriteria) *File {
 		return f
 	}
 	return nil
+}
+
+// LatestToolsFile searches the whole JFrog instance (not just the current
+// build) for the most recently created "aerospike-tools_*.tgz" matching the
+// given OS and architecture. It is the second-preference fallback used when
+// the resolved build has no matching tools artifact of its own. Returns
+// nil (no error) when nothing matches.
+func (c *Config) LatestToolsFile(ctx context.Context, osName, osVersion, arch string) (*File, error) {
+	if c == nil {
+		return nil, fmt.Errorf("jfrog: nil config")
+	}
+	tag := osTag(osName, osVersion)
+	if tag == "" {
+		return nil, fmt.Errorf("jfrog: unsupported OS %q for tools lookup", osName)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.timeout())
+		defer cancel()
+	}
+
+	glob := fmt.Sprintf("aerospike-tools_*_%s_%s.tgz", tag, arch)
+	query := fmt.Sprintf(
+		`items.find({"name":{"$match":"%s"}}).include("repo","path","name","size","actual_sha1","created").sort({"$desc":["created"]}).limit(50)`,
+		jsonEscape(glob),
+	)
+	raw, err := c.AQL(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Results []struct {
+			Repo    string    `json:"repo"`
+			Path    string    `json:"path"`
+			Name    string    `json:"name"`
+			Size    int64     `json:"size"`
+			SHA1    string    `json:"actual_sha1"`
+			Created time.Time `json:"created"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("jfrog: parse tools AQL response: %w", err)
+	}
+	// Results are created-desc; return the first that actually parses and
+	// matches (the glob is a coarse filter, ParseToolsFileName is exact).
+	for _, r := range resp.Results {
+		tp := ParseToolsFileName(r.Name)
+		if tp == nil || tp.OSName != osName || tp.OSVersion != osVersion || tp.Arch != arch {
+			continue
+		}
+		return &File{
+			Repo:        r.Repo,
+			Path:        r.Path,
+			Name:        r.Name,
+			Size:        r.Size,
+			SHA1:        r.SHA1,
+			Created:     r.Created,
+			DownloadURL: c.ArtifactoryURL("/" + r.Repo + "/" + r.Path + "/" + r.Name),
+			Parts:       ParseFileName(r.Name),
+		}, nil
+	}
+	return nil, nil
 }
 
 // formatForOS returns the package format JFrog publishes for a given OS.

--- a/pkg/utils/installers/aerospike/jfrog/files.go
+++ b/pkg/utils/installers/aerospike/jfrog/files.go
@@ -82,6 +82,26 @@ func (fs Files) Match(c MatchCriteria) (*File, error) {
 		c.Edition, wantFormat, c.OSName, c.OSVersion, c.Arch, c.Edition, seen)
 }
 
+// MatchTools returns the "aerospike-tools_*.tgz" artifact matching the OS
+// and architecture in c. Edition and package format are ignored — the tools
+// bundle is edition-agnostic and always shipped as a .tgz. Returns nil when
+// the build has no matching tools package, so callers can fall back to a
+// server-only install (and warn the operator).
+func (fs Files) MatchTools(c MatchCriteria) *File {
+	for i := range fs {
+		f := &fs[i]
+		tp := ParseToolsFileName(f.Name)
+		if tp == nil {
+			continue
+		}
+		if tp.OSName != c.OSName || tp.OSVersion != c.OSVersion || tp.Arch != c.Arch {
+			continue
+		}
+		return f
+	}
+	return nil
+}
+
 // formatForOS returns the package format JFrog publishes for a given OS.
 func formatForOS(osName string) string {
 	switch osName {

--- a/pkg/utils/installers/aerospike/jfrog/parser.go
+++ b/pkg/utils/installers/aerospike/jfrog/parser.go
@@ -142,6 +142,23 @@ func splitOSTag(tag string) (osName, osVersion string) {
 	return "", tag
 }
 
+// osTag is the inverse of splitOSTag: it renders an (osName, osVersion)
+// pair back into the JFrog filename tag ("ubuntu24.04", "amzn2023",
+// "el9", "debian12"). Returns "" for OS names JFrog does not publish.
+func osTag(osName, osVersion string) string {
+	switch osName {
+	case "amazon":
+		return "amzn" + osVersion
+	case "centos", "rocky":
+		return "el" + osVersion
+	case "debian":
+		return "debian" + osVersion
+	case "ubuntu":
+		return "ubuntu" + osVersion
+	}
+	return ""
+}
+
 // debArch maps Debian's package arch labels to the rpm/aerolab labels so
 // the matcher only ever has to think in one vocabulary.
 func debArch(in string) string {

--- a/pkg/utils/installers/aerospike/jfrog/parser.go
+++ b/pkg/utils/installers/aerospike/jfrog/parser.go
@@ -55,6 +55,47 @@ var debRE = regexp.MustCompile(
 		`_(amd64|arm64)\.deb$`,
 )
 
+// ToolsParts is the parsed form of an "aerospike-tools_*.tgz" artifact.
+// The tools bundle (asinfo, asadm, aql, …) is edition-agnostic, so unlike
+// NameParts it carries no edition/release/format.
+type ToolsParts struct {
+	Version   string // 11.2.2
+	OSName    string // amazon | centos | debian | ubuntu
+	OSVersion string // 2023 | 9 | 12 | 24.04
+	Arch      string // x86_64 | aarch64
+}
+
+// tools: [prefix-]aerospike-tools_{version}_{osTag}_{arch}.tgz
+//
+//	aerospike-tools_11.2.2_ubuntu24.04_aarch64.tgz
+//	aerospike-tools_11.2.2_ubuntu24.04_x86_64.tgz
+//	aerospike-tools_11.2.2_amzn2023_x86_64.tgz
+//
+// The optional prefix mirrors the server parser so double-prefixed CI
+// names (e.g. "aerospike-aerospike-tools_...") still match.
+var toolsRE = regexp.MustCompile(
+	`^(?:.*?-)?aerospike-tools_` +
+		`([0-9][0-9.]*)_` +
+		`((?:amzn|el|debian|ubuntu)[0-9]+(?:\.[0-9]+)?)_` +
+		`(x86_64|aarch64)\.tgz$`,
+)
+
+// ParseToolsFileName returns the parsed ToolsParts, or nil if the name is
+// not an Aerospike tools .tgz.
+func ParseToolsFileName(name string) *ToolsParts {
+	m := toolsRE.FindStringSubmatch(name)
+	if m == nil {
+		return nil
+	}
+	os, ver := splitOSTag(m[2])
+	return &ToolsParts{
+		Version:   m[1],
+		OSName:    os,
+		OSVersion: ver,
+		Arch:      m[3],
+	}
+}
+
 // ParseFileName returns the parsed NameParts, or nil if the name does not
 // match an Aerospike server RPM or DEB.
 func ParseFileName(name string) *NameParts {

--- a/pkg/utils/installers/aerospike/jfrog/parser_test.go
+++ b/pkg/utils/installers/aerospike/jfrog/parser_test.go
@@ -168,10 +168,10 @@ func TestMatchTools(t *testing.T) {
 
 func TestEditionFromInput(t *testing.T) {
 	cases := []struct {
-		in           string
-		def          string
-		wantEdition  string
-		wantVersion  string
+		in          string
+		def         string
+		wantEdition string
+		wantVersion string
 	}{
 		{"8.1.3.0-28-g302194ebc", "enterprise", "enterprise", "8.1.3.0-28-g302194ebc"},
 		// git SHA ending in 'c' must NOT be treated as community shorthand

--- a/pkg/utils/installers/aerospike/jfrog/parser_test.go
+++ b/pkg/utils/installers/aerospike/jfrog/parser_test.go
@@ -92,6 +92,80 @@ func TestParseFileName_Ignored(t *testing.T) {
 	}
 }
 
+func TestParseToolsFileName(t *testing.T) {
+	cases := []struct {
+		name string
+		want ToolsParts
+	}{
+		{
+			"aerospike-tools_11.2.2_ubuntu24.04_aarch64.tgz",
+			ToolsParts{Version: "11.2.2", OSName: "ubuntu", OSVersion: "24.04", Arch: "aarch64"},
+		},
+		{
+			"aerospike-tools_11.2.2_ubuntu24.04_x86_64.tgz",
+			ToolsParts{Version: "11.2.2", OSName: "ubuntu", OSVersion: "24.04", Arch: "x86_64"},
+		},
+		{
+			"aerospike-tools_11.2.2_amzn2023_x86_64.tgz",
+			ToolsParts{Version: "11.2.2", OSName: "amazon", OSVersion: "2023", Arch: "x86_64"},
+		},
+		{
+			"aerospike-tools_11.2.2_el9_aarch64.tgz",
+			ToolsParts{Version: "11.2.2", OSName: "centos", OSVersion: "9", Arch: "aarch64"},
+		},
+		{
+			"aerospike-tools_11.2.2_debian12_x86_64.tgz",
+			ToolsParts{Version: "11.2.2", OSName: "debian", OSVersion: "12", Arch: "x86_64"},
+		},
+		// resilient: double "aerospike-" prefix
+		{
+			"aerospike-aerospike-tools_11.2.2_ubuntu24.04_aarch64.tgz",
+			ToolsParts{Version: "11.2.2", OSName: "ubuntu", OSVersion: "24.04", Arch: "aarch64"},
+		},
+	}
+	for _, tc := range cases {
+		got := ParseToolsFileName(tc.name)
+		if got == nil {
+			t.Errorf("%s: parse returned nil", tc.name)
+			continue
+		}
+		if *got != tc.want {
+			t.Errorf("%s:\n  got  %+v\n  want %+v", tc.name, *got, tc.want)
+		}
+	}
+
+	// non-tools names must not parse as tools
+	for _, n := range []string{
+		"aerospike-server-enterprise_8.0.0.8_ubuntu24.04_x86_64.tgz",
+		"aerospike-tools_11.2.2_ubuntu24.04_aarch64.tgz.asc",
+		"aerospike-server-community-8.1.3.0-28.amzn2023.aarch64.rpm",
+		"random.txt",
+		"",
+	} {
+		if got := ParseToolsFileName(n); got != nil {
+			t.Errorf("%s: expected nil, got %+v", n, *got)
+		}
+	}
+}
+
+func TestMatchTools(t *testing.T) {
+	fs := Files{
+		{Name: "aerospike-server-enterprise_8.1.3.0-28ubuntu24.04_arm64.deb", Parts: ParseFileName("aerospike-server-enterprise_8.1.3.0-28ubuntu24.04_arm64.deb")},
+		{Name: "aerospike-tools_11.2.2_ubuntu24.04_x86_64.tgz"},
+		{Name: "aerospike-tools_11.2.2_ubuntu24.04_aarch64.tgz"},
+	}
+	got := fs.MatchTools(MatchCriteria{OSName: "ubuntu", OSVersion: "24.04", Arch: "aarch64"})
+	if got == nil || got.Name != "aerospike-tools_11.2.2_ubuntu24.04_aarch64.tgz" {
+		t.Fatalf("MatchTools aarch64: got %v", got)
+	}
+	if got := fs.MatchTools(MatchCriteria{OSName: "ubuntu", OSVersion: "24.04", Arch: "x86_64"}); got == nil || got.Name != "aerospike-tools_11.2.2_ubuntu24.04_x86_64.tgz" {
+		t.Fatalf("MatchTools x86_64: got %v", got)
+	}
+	if got := fs.MatchTools(MatchCriteria{OSName: "debian", OSVersion: "12", Arch: "x86_64"}); got != nil {
+		t.Fatalf("MatchTools miss: expected nil, got %v", got)
+	}
+}
+
 func TestEditionFromInput(t *testing.T) {
 	cases := []struct {
 		in           string

--- a/pkg/utils/installers/aerospike/jfrog/scripts.go
+++ b/pkg/utils/installers/aerospike/jfrog/scripts.go
@@ -70,6 +70,24 @@ func InstallScript(f *File, debug, upgrade bool) ([]byte, error) {
 	return append(base, pkg...), nil
 }
 
+// ToolsInstallScript returns a bash snippet that installs the pre-uploaded
+// aerospike-tools .tgz at RemoteFileDir/<name> (extract + run ./asinstall).
+// It is meant to be appended after the server InstallScript so JFrog-built
+// templates carry asinfo/asadm/aql just like the public .tgz flow does.
+func ToolsInstallScript(f *File, upgrade bool) ([]byte, error) {
+	if f == nil {
+		return nil, fmt.Errorf("jfrog: tools install script needs a file")
+	}
+	data := struct {
+		FileName string
+		Upgrade  bool
+	}{
+		FileName: RemoteFileDir + "/" + f.Name,
+		Upgrade:  upgrade,
+	}
+	return renderTemplate("scripts/install_tools.sh.tpl", data)
+}
+
 func renderTemplate(name string, data any) ([]byte, error) {
 	raw, err := scriptsFS.ReadFile(name)
 	if err != nil {

--- a/pkg/utils/installers/aerospike/jfrog/scripts/install_tools.sh.tpl
+++ b/pkg/utils/installers/aerospike/jfrog/scripts/install_tools.sh.tpl
@@ -1,0 +1,48 @@
+# shellcheck disable=SC2148
+UPGRADE="{{.Upgrade}}"
+if [ "$UPGRADE" != "true" ]; then
+    if command -v asinfo &> /dev/null; then
+        echo "Aerospike tools are already installed"
+        exit 0
+    fi
+fi
+
+FILE_NAME="{{.FileName}}"
+
+if [ ! -f "$FILE_NAME" ]; then
+    echo "Tools package file $FILE_NAME not found"
+    exit 1
+fi
+
+fileDir=$(dirname "$FILE_NAME")
+pushd "$fileDir" || exit 1
+
+# get the top level directory name from the tar archive
+topDir=$(tar -tzf "$FILE_NAME" | head -1 | cut -f1 -d"/")
+if [ -z "$topDir" ]; then
+    echo "Could not determine top directory name from tar archive"
+    exit 1
+fi
+
+# extract the file
+tar -xzf "$FILE_NAME" || exit 1
+
+# check if the installer exists
+if [ ! -f "$topDir/asinstall" ]; then
+    echo "File $topDir/asinstall not found after attempting to extract"
+    exit 1
+fi
+
+# run the install script
+pushd "$topDir" || exit 1
+./asinstall || exit 1
+popd || exit 1
+
+# check if it installed successfully
+if ! command -v asinfo &> /dev/null; then
+    echo "Aerospike tools are not installed after attempting to install"
+    exit 1
+fi
+
+# done
+popd || exit 1


### PR DESCRIPTION
Draft PR opened by **Tiger** (automated agent). Review before merging.

**Repo:** `aerolab`  
**Base:** `v8.0.0`

**Task:**
> Fixed JFrog-mode cluster templates to include the aerospike-tools bundle (asinfo, asadm, aql), which was missing and caused roster commands to fail with exit status 127. The fix downloads and installs the matching aerospike-tools_*.tgz artifact alongside the server package during template creation, making JFrog templates interchangeable with the public flow.

**Tiger's summary:**

Fixed and committed. Here's the summary for the thread:

## Fix committed ✅

**Root cause** (as diagnosed): JFrog-mode template creation installed only the `aerospike-server` `.deb`/`.rpm`, which ships `asd` but **not** the tools bundle (`asinfo`/`asadm`/`aql`). The public flow gets those for free from the all-in-one server `.tgz`'s `asinstall`, so JFrog templates weren't actually interchangeable — `roster apply` (and `roster show`, `aerospike-is-stable`, `attach asinfo`) shelled out to a bare `asinfo` that didn't exist → `exit status 127`.

**What the fix does** (`091cc348`): in JFrog mode, aerolab now also locates the matching `aerospike-tools_*.tgz` in the **same build**, downloads/uploads it to each instance, and installs it (extract + `./asinstall`) right after the server package — so `asinfo`/`asadm`/`aql` land on the node just like the public flow. If the build has no matching tools artifact for your OS/arch, it logs a loud warning and continues with a server-only install rather than failing the whole template create.

Files: JFrog tools-name parser + `MatchTools` picker + a tgz install script/template, wired into `resolveJFrogPlan` and the template upload loop. `go build`/`go vet`/`go test` all pass (added unit tests for the new parsing/matching). ⚠️ It's built against the JFrog install path, which I **can't exercise end-to-end here** (no JFrog creds/build in the sandbox), so please give it a run against a real build before merging the draft PR.

## Your current cluster (813)

The fix only affects **newly created** templates/clusters. Cluster 813 was already built without the tools, so either:
- **Recreate** it with the patched build (cleanest), or
- **Patch it in place** now: grab `aerospike-tools_<ver>_<osTag>_<arch>.tgz` from the same JFrog build and install it —
  ```
  aerolab files upload -n 813 aerospike-tools_<ver>_<osTag>_<arch>.tgz /root/tools.tgz
  aerolab attach shell -n 813 -l all -- bash -c "cd /root && tar xzf tools.tgz && cd aerospike-tools* && ./asinstall"
  ```
  then re-run `aerolab roster apply -n 813`.
