### PR TITLE
Fix some data races

### DIFF
--- a/pkg/backend/backends/backendInventories.go
+++ b/pkg/backend/backends/backendInventories.go
@@ -393,18 +393,21 @@ func (b *backend) loadCache() error {
 
 func (b *backend) poll(items []string) []error {
 	start := time.Now()
-	var errs []error
+	var (
+		errs     []error
+		errsLock sync.Mutex
+	)
 
 	log := b.log.WithPrefix("PollInventory ")
 
 	slices.Sort(items)
 	items = slices.Compact(items)
 
-	netWg := new(sync.WaitGroup)
-	fwWg := new(sync.WaitGroup)
-	volWg := new(sync.WaitGroup)
-	instWg := new(sync.WaitGroup)
-	imgWg := new(sync.WaitGroup)
+	var netWg sync.WaitGroup
+	var fwWg sync.WaitGroup
+	var volWg sync.WaitGroup
+	var instWg sync.WaitGroup
+	var imgWg sync.WaitGroup
 
 	// images can run immediately
 	imgWg.Go(func() {
@@ -413,14 +416,18 @@ func (b *backend) poll(items []string) []error {
 			for n, v := range b.enabledBackends {
 				d, err := v.GetImages()
 				if err != nil {
+					errsLock.Lock()
 					errs = append(errs, err)
+					errsLock.Unlock()
 				} else {
 					b.images[n] = d
 				}
 			}
 			err := b.cache.Store(path.Join(b.project, "images"), b.images)
 			if err != nil {
+				errsLock.Lock()
 				errs = append(errs, err)
+				errsLock.Unlock()
 			}
 		}
 	})
@@ -432,14 +439,18 @@ func (b *backend) poll(items []string) []error {
 			for n, v := range b.enabledBackends {
 				d, err := v.GetVolumes()
 				if err != nil {
+					errsLock.Lock()
 					errs = append(errs, err)
+					errsLock.Unlock()
 				} else {
 					b.volumes[n] = d
 				}
 			}
 			err := b.cache.Store(path.Join(b.project, "volumes"), b.volumes)
 			if err != nil {
+				errsLock.Lock()
 				errs = append(errs, err)
+				errsLock.Unlock()
 			}
 		}
 	})
@@ -450,14 +461,18 @@ func (b *backend) poll(items []string) []error {
 			for n, v := range b.enabledBackends {
 				d, err := v.GetNetworks()
 				if err != nil {
+					errsLock.Lock()
 					errs = append(errs, err)
+					errsLock.Unlock()
 				} else {
 					b.networks[n] = d
 				}
 			}
 			err := b.cache.Store(path.Join(b.project, "networks"), b.networks)
 			if err != nil {
+				errsLock.Lock()
 				errs = append(errs, err)
+				errsLock.Unlock()
 			}
 		}
 	})
@@ -469,14 +484,18 @@ func (b *backend) poll(items []string) []error {
 			for n, v := range b.enabledBackends {
 				d, err := v.GetFirewalls(b.networks[n])
 				if err != nil {
+					errsLock.Lock()
 					errs = append(errs, err)
+					errsLock.Unlock()
 				} else {
 					b.firewalls[n] = d
 				}
 			}
 			err := b.cache.Store(path.Join(b.project, "firewalls"), b.firewalls)
 			if err != nil {
+				errsLock.Lock()
 				errs = append(errs, err)
+				errsLock.Unlock()
 			}
 		}
 	})
@@ -489,14 +508,18 @@ func (b *backend) poll(items []string) []error {
 			for n, v := range b.enabledBackends {
 				d, err := v.GetInstances(b.volumes[n], b.networks[n], b.firewalls[n])
 				if err != nil {
+					errsLock.Lock()
 					errs = append(errs, err)
+					errsLock.Unlock()
 				} else {
 					b.instances[n] = d
 				}
 			}
 			err := b.cache.Store(path.Join(b.project, "instances"), b.instances)
 			if err != nil {
+				errsLock.Lock()
 				errs = append(errs, err)
+				errsLock.Unlock()
 			}
 		}
 	})

--- a/pkg/backend/clouds/bdocker/images.go
+++ b/pkg/backend/clouds/bdocker/images.go
@@ -100,21 +100,26 @@ func (s *b) GetImages() (backends.ImageList, error) {
 	log := s.log.WithPrefix("GetImages: job=" + shortuuid.New() + " ")
 	log.Detail("Start")
 	defer log.Detail("End")
-	var i backends.ImageList
-	ilock := new(sync.Mutex)
-	wg := new(sync.WaitGroup)
+	var wg sync.WaitGroup
 	zones, _ := s.ListEnabledZones()
-	var errs error
-	wg.Add(len(zones) * 2)
+
+	var (
+		iLock sync.Mutex
+		i     backends.ImageList
+
+		errsLock sync.Mutex
+		errs     error
+	)
 
 	for _, zone := range zones {
-		go func(zone string) {
-			defer wg.Done()
+		wg.Go(func() {
 			log.Detail("zone=%s owned: start", zone)
 			defer log.Detail("zone=%s owned: end", zone)
 			cli, err := s.getDockerClient(zone)
 			if err != nil {
+				errsLock.Lock()
 				errs = errors.Join(errs, err)
+				errsLock.Unlock()
 				return
 			}
 			f := filters.NewArgs()
@@ -128,7 +133,9 @@ func (s *b) GetImages() (backends.ImageList, error) {
 				Filters:        f,
 			})
 			if err != nil {
+				errsLock.Lock()
 				errs = errors.Join(errs, err)
+				errsLock.Unlock()
 				return
 			}
 			for distro, versions := range distrosMap {
@@ -159,6 +166,7 @@ func (s *b) GetImages() (backends.ImageList, error) {
 						if sdImg != nil {
 							size = math.Ceil(float64(sdImg.Size)/1024/1024/1024) * 1024 * 1024 * 1024
 						}
+						iLock.Lock()
 						i = append(i, &backends.Image{
 							BackendType:  backends.BackendTypeDocker,
 							Name:         imageName,
@@ -182,20 +190,22 @@ func (s *b) GetImages() (backends.ImageList, error) {
 								Docker: sdImg,
 							},
 						})
+						iLock.Unlock()
 					}
 				}
 			}
-		}(zone)
+		})
 	}
 
 	for _, zone := range zones {
-		go func(zone string) {
-			defer wg.Done()
+		wg.Go(func() {
 			log.Detail("zone=%s owned: start", zone)
 			defer log.Detail("zone=%s owned: end", zone)
 			cli, err := s.getDockerClient(zone)
 			if err != nil {
+				errsLock.Lock()
 				errs = errors.Join(errs, err)
+				errsLock.Unlock()
 				return
 			}
 			f := filters.NewArgs()
@@ -209,7 +219,9 @@ func (s *b) GetImages() (backends.ImageList, error) {
 				Filters:        f,
 			})
 			if err != nil {
+				errsLock.Lock()
 				errs = errors.Join(errs, err)
+				errsLock.Unlock()
 				return
 			}
 			for _, image := range out {
@@ -230,7 +242,7 @@ func (s *b) GetImages() (backends.ImageList, error) {
 					arch = backends.ArchitectureARM64
 				}
 				img := image
-				ilock.Lock()
+				iLock.Lock()
 				i = append(i, &backends.Image{
 					BackendType:  backends.BackendTypeDocker,
 					Name:         name,
@@ -254,9 +266,9 @@ func (s *b) GetImages() (backends.ImageList, error) {
 						Docker: &img,
 					},
 				})
-				ilock.Unlock()
+				iLock.Unlock()
 			}
-		}(zone)
+		})
 	}
 	wg.Wait()
 	if errs == nil {


### PR DESCRIPTION
I am doing abusive testing of Voyager. Here is what it surfaced so far:

 - pkg/backend/backends/backendInventories.go: `errs` was not protected
 - pkg/backend/clouds/bdocker/images.go: `i` and `errs` were not protected

This only fixes the races that I saw happen. I bet that an audit of the code will find more.

Also, in functions that I was already touching
 - fix odd uses of `new`
 - don't worry about the old loop var gotcha
 - prefer `wg.Go`