### PR TITLE
[tiger] Fix enterprise server artifact parsing and .tgz bundle support

### DIFF
--- a/docs/reference/jfrog-dev-builds.md
+++ b/docs/reference/jfrog-dev-builds.md
@@ -104,6 +104,38 @@ After destroying the template, the next `cluster create` rebuilds it from the cu
 
 ---
 
+## 6. Troubleshooting: "no &lt;edition&gt; deb/rpm package found"
+
+Aerolab picks an artifact off the build by parsing its **filename**, accepting:
+
+```
+aerospike-server-<edition>_<version>-<release><osTag>_<amd64|arm64>.deb
+aerospike-server-<edition>-<version>-<release>.<osTag>.<x86_64|aarch64>.rpm
+aerospike-server-<edition>_<version>_<osTag>_<x86_64|aarch64>.tgz   # self-contained bundle
+```
+
+where `<osTag>` is `ubuntu24.04`, `debian12`, `el9`, `amzn2023`, … Release fields may be a
+plain number or a git describe (`70-g282a6817d`), an extra build tag (`-TEST`) or a doubled
+`aerospike-` prefix is fine, and the native package is preferred over the `.tgz` bundle when
+a build ships both.
+
+If nothing on the build matches, the error now lists the artifacts that *were* on it. Two
+common causes:
+
+- **The distro/arch you asked for was not built.** The error lists the editions/OS versions
+  it did find — pick one of those.
+- **Your JFrog credentials cannot read the repository the package lives in.** AQL silently
+  omits artifacts you have no read permission on, so the build looks like it has no
+  enterprise packages at all. Confirm with a direct query and compare against the JFrog UI:
+
+  ```bash
+  curl -s -H "Authorization: Bearer $AEROLAB_ARTIFACTS_AUTH" -H "Content-Type: text/plain" \
+    -X POST "$AEROLAB_ARTIFACTS_URL/artifactory/api/search/aql" \
+    --data 'items.find({"@build.name":"aerospike-server","@build.number":"<build>-artifacts"}).include("repo","path","name")'
+  ```
+
+---
+
 ## Quick reference
 
 ```bash

--- a/pkg/utils/installers/aerospike/jfrog/files.go
+++ b/pkg/utils/installers/aerospike/jfrog/files.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -35,53 +36,113 @@ type MatchCriteria struct {
 	Edition   string
 }
 
-// Match returns the single File matching the criteria. The choice of
-// package format (rpm vs deb) is implied by OSName: amazon/centos use
-// rpm, debian/ubuntu use deb.
+// Match returns the single File matching the criteria. The native package
+// format (rpm vs deb) is implied by OSName: amazon/centos use rpm,
+// debian/ubuntu use deb. Builds that ship the self-contained
+// "aerospike-server-<edition>_<version>_<osTag>_<arch>.tgz" bundle instead of
+// (or as well as) loose packages are handled too — the native package is
+// preferred and the bundle is the fallback, since both install the same
+// server via the same OS package underneath.
 func (fs Files) Match(c MatchCriteria) (*File, error) {
 	wantFormat := formatForOS(c.OSName)
 	if wantFormat == "" {
 		return nil, fmt.Errorf("jfrog: unsupported OS %q (only amazon/centos/debian/ubuntu have JFrog packages)", c.OSName)
 	}
 
-	var seen []string
+	for _, format := range []string{wantFormat, "tgz"} {
+		for i := range fs {
+			f := &fs[i]
+			if f.Parts == nil {
+				continue
+			}
+			if f.Parts.Format != format {
+				continue
+			}
+			if f.Parts.Edition != c.Edition {
+				continue
+			}
+			if f.Parts.OSName != c.OSName {
+				continue
+			}
+			if f.Parts.OSVersion != c.OSVersion {
+				continue
+			}
+			if f.Parts.Arch != c.Arch {
+				continue
+			}
+			return f, nil
+		}
+	}
+	return nil, fs.noMatchError(c, wantFormat)
+}
+
+// diagSampleSize caps how many artifact names a failed match reports. A
+// build carries hundreds of artifacts; a sample is enough to tell whether the
+// package is missing, named unexpectedly, or hidden by repository
+// permissions, without burying the error.
+const diagSampleSize = 15
+
+// noMatchError explains a failed Match. When packages for the requested
+// edition exist it lists them; when none do it samples what the build
+// actually carried, because that is the only place the operator can see it —
+// the artifact list is fetched, matched and discarded in one call.
+func (fs Files) noMatchError(c MatchCriteria, wantFormat string) error {
+	var candidates, others []string
 	for i := range fs {
 		f := &fs[i]
-		if f.Parts == nil {
-			continue
-		}
-		if f.Parts.Format != wantFormat {
-			continue
-		}
-		if f.Parts.Edition != c.Edition {
-			continue
-		}
-		if f.Parts.OSName != c.OSName {
-			continue
-		}
-		if f.Parts.OSVersion != c.OSVersion {
-			continue
-		}
-		if f.Parts.Arch != c.Arch {
-			continue
-		}
-		return f, nil
-	}
-
-	// build a helpful "what we did see" message for the user
-	for _, f := range fs {
-		if f.Parts != nil && f.Parts.Edition == c.Edition && f.Parts.Format == wantFormat {
-			seen = append(seen, fmt.Sprintf("%s/%s/%s",
+		if f.Parts != nil && f.Parts.Edition == c.Edition &&
+			(f.Parts.Format == wantFormat || f.Parts.Format == "tgz") {
+			candidates = append(candidates, fmt.Sprintf("%s/%s/%s",
 				f.Parts.OSName+f.Parts.OSVersion, f.Parts.Arch, f.Name))
+			continue
 		}
+		others = append(others, f.pathName())
 	}
-	if len(seen) == 0 {
-		return nil, fmt.Errorf("jfrog: no %s %s package found for %s/%s/%s",
-			c.Edition, wantFormat, c.OSName, c.OSVersion, c.Arch)
+	if len(candidates) > 0 {
+		return fmt.Errorf(
+			"jfrog: no %s %s package matches %s %s %s; available %s candidates: %v",
+			c.Edition, wantFormat, c.OSName, c.OSVersion, c.Arch, c.Edition, candidates)
 	}
-	return nil, fmt.Errorf(
-		"jfrog: no %s %s package matches %s %s %s; available %s candidates: %v",
-		c.Edition, wantFormat, c.OSName, c.OSVersion, c.Arch, c.Edition, seen)
+	tag := osTag(c.OSName, c.OSVersion)
+	debArchName := "amd64"
+	if c.Arch == "aarch64" {
+		debArchName = "arm64"
+	}
+	example := fmt.Sprintf("aerospike-server-%s-<version>-<release>.%s.%s.rpm", c.Edition, tag, c.Arch)
+	if wantFormat == "deb" {
+		example = fmt.Sprintf("aerospike-server-%s_<version>-<release>%s_%s.deb", c.Edition, tag, debArchName)
+	}
+	return fmt.Errorf(
+		"jfrog: no %s %s (or .tgz bundle) package found for %s/%s/%s; "+
+			"none of the %d artifacts on this build parsed as an %s server package. "+
+			"Expected a name such as %s or aerospike-server-%s_<version>_%s_%s.tgz. "+
+			"If the build genuinely has none, the package may live in a repository your "+
+			"JFrog credentials cannot read (AQL silently omits those). Artifacts on the build: %s",
+		c.Edition, wantFormat, c.OSName, c.OSVersion, c.Arch,
+		len(fs), c.Edition,
+		example, c.Edition, tag, c.Arch,
+		sample(others, diagSampleSize))
+}
+
+// pathName renders a file as "<path>/<name>" so the sample also shows the
+// repository layout (some pipelines encode the distro in the path rather
+// than the filename).
+func (f *File) pathName() string {
+	if f.Path == "" {
+		return f.Name
+	}
+	return strings.TrimSuffix(f.Path, "/") + "/" + f.Name
+}
+
+// sample renders at most max entries of in, noting how many were elided.
+func sample(in []string, max int) string {
+	if len(in) == 0 {
+		return "(none)"
+	}
+	if len(in) <= max {
+		return strings.Join(in, ", ")
+	}
+	return fmt.Sprintf("%s, ... (+%d more)", strings.Join(in[:max], ", "), len(in)-max)
 }
 
 // MatchTools returns the "aerospike-tools_*.tgz" artifact matching the OS

--- a/pkg/utils/installers/aerospike/jfrog/files_test.go
+++ b/pkg/utils/installers/aerospike/jfrog/files_test.go
@@ -1,0 +1,106 @@
+package jfrog
+
+import (
+	"strings"
+	"testing"
+)
+
+func file(repo, path, name string) File {
+	return File{Repo: repo, Path: path, Name: name, Parts: ParseFileName(name)}
+}
+
+func TestMatch_PrefersNativePackageOverBundle(t *testing.T) {
+	fs := Files{
+		file("d", "pool/noble", "aerospike-server-enterprise_8.1.3.0_ubuntu24.04_x86_64.tgz"),
+		file("d", "pool/noble", "aerospike-server-enterprise_8.1.3.0-70ubuntu24.04_amd64.deb"),
+	}
+	got, err := fs.Match(MatchCriteria{Edition: "enterprise", OSName: "ubuntu", OSVersion: "24.04", Arch: "x86_64"})
+	if err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	if !strings.HasSuffix(got.Name, ".deb") {
+		t.Fatalf("expected the deb to win over the tgz bundle, got %s", got.Name)
+	}
+}
+
+func TestMatch_FallsBackToBundle(t *testing.T) {
+	fs := Files{
+		file("d", "x", "aerospike-server-enterprise_8.1.3.0_ubuntu24.04_x86_64.tgz"),
+		file("d", "x", "aerospike-server-enterprise_8.1.3.0_ubuntu24.04_aarch64.tgz"),
+	}
+	got, err := fs.Match(MatchCriteria{Edition: "enterprise", OSName: "ubuntu", OSVersion: "24.04", Arch: "x86_64"})
+	if err != nil {
+		t.Fatalf("Match: %v", err)
+	}
+	if got.Name != "aerospike-server-enterprise_8.1.3.0_ubuntu24.04_x86_64.tgz" {
+		t.Fatalf("wrong artifact: %s", got.Name)
+	}
+	if got.Parts.Format != "tgz" {
+		t.Fatalf("format = %q, want tgz", got.Parts.Format)
+	}
+}
+
+func TestMatch_ErrorListsCandidates(t *testing.T) {
+	fs := Files{
+		file("d", "x", "aerospike-server-enterprise_8.1.3.0-70ubuntu22.04_amd64.deb"),
+	}
+	_, err := fs.Match(MatchCriteria{Edition: "enterprise", OSName: "ubuntu", OSVersion: "24.04", Arch: "x86_64"})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "ubuntu22.04") {
+		t.Fatalf("error should list the candidates it saw: %v", err)
+	}
+}
+
+// The build carries artifacts, but none of them parse as a server package.
+// This is the case that used to dead-end with "no enterprise deb package
+// found" and nothing else to go on.
+func TestMatch_ErrorSamplesUnparsedArtifacts(t *testing.T) {
+	fs := Files{
+		file("d", "pool/noble", "aerospike-server-enterprise_8.1.3.0-70_amd64.deb"), // no OS tag in the name
+		file("d", "container", "aerospike-server-enterprise-docker_8.1.3.0_x86_64.tgz"),
+		file("d", "sig", "aerospike-server-enterprise_8.1.3.0-70ubuntu24.04_amd64.deb.asc"),
+	}
+	_, err := fs.Match(MatchCriteria{Edition: "enterprise", OSName: "ubuntu", OSVersion: "24.04", Arch: "x86_64"})
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"none of the 3 artifacts",
+		"pool/noble/aerospike-server-enterprise_8.1.3.0-70_amd64.deb",
+		"aerospike-server-enterprise_<version>-<release>ubuntu24.04_amd64.deb",
+		"aerospike-server-enterprise_<version>_ubuntu24.04_x86_64.tgz",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestSample(t *testing.T) {
+	if got := sample(nil, 3); got != "(none)" {
+		t.Errorf("empty sample = %q", got)
+	}
+	if got := sample([]string{"a", "b"}, 3); got != "a, b" {
+		t.Errorf("short sample = %q", got)
+	}
+	if got := sample([]string{"a", "b", "c", "d"}, 2); got != "a, b, ... (+2 more)" {
+		t.Errorf("truncated sample = %q", got)
+	}
+}
+
+func TestInstallScript_TGZBundle(t *testing.T) {
+	f := file("d", "x", "aerospike-server-enterprise_8.1.3.0_ubuntu24.04_x86_64.tgz")
+	script, err := InstallScript(&f, false, false)
+	if err != nil {
+		t.Fatalf("InstallScript: %v", err)
+	}
+	s := string(script)
+	for _, want := range []string{"/opt/aerolab/files/" + f.Name, "./asinstall", "command -v asd"} {
+		if !strings.Contains(s, want) {
+			t.Errorf("script missing %q", want)
+		}
+	}
+}

--- a/pkg/utils/installers/aerospike/jfrog/parser.go
+++ b/pkg/utils/installers/aerospike/jfrog/parser.go
@@ -6,54 +6,60 @@ import (
 )
 
 // NameParts is the parsed form of a JFrog artifact filename. Only the
-// "aerospike-server-{edition}" RPM/DEB packages used by the cluster-create
-// flow are parsed; everything else (asc signatures, source tarballs, etc.)
-// returns nil.
+// "aerospike-server-{edition}" packages used by the cluster-create flow are
+// parsed; everything else (asc signatures, checksums, container images,
+// source tarballs, …) returns nil.
 type NameParts struct {
 	Edition   string // community | enterprise | federal
 	Version   string // 8.1.3.0
-	Release   string // 28
+	Release   string // 28 | 70-g282a6817d | "" (absent)
 	OSName    string // amazon | centos | debian | ubuntu
 	OSVersion string // 2023 | 9 | 12 | 24.04
 	Arch      string // x86_64 | aarch64    (normalised to aerospike package conventions)
-	Format    string // rpm | deb
+	Format    string // rpm | deb | tgz
 }
 
-// Resilient matching notes:
-//   - An optional prefix ending in "-" is allowed before "aerospike-server-"
-//     so double-prefixed CI names like "aerospike-aerospike-server-..." match.
-//   - An optional tag (e.g. "-TEST") may sit between the edition and the
-//     version separator, so names like
-//     "aerospike-aerospike-server-enterprise-TEST_8.1.3.0-36ubuntu24.04_arm64.deb"
-//     match. For rpm the tag segments must start with a letter so they can't
-//     eat the numeric version that follows the "-" separator.
+// Parsing strategy: JFrog builds are produced by several different pipelines
+// and the exact separator layout of an artifact name has changed more than
+// once (numeric vs git-describe release fields, "-TEST" tags, doubled
+// "aerospike-" prefixes, self-contained .tgz bundles alongside loose
+// .deb/.rpm packages). Matching one rigid full-name regex per format made a
+// single unexpected name silently invisible to the matcher, which surfaced to
+// users as "no <edition> <format> package found" with no way to tell why.
+//
+// So the name is tokenised around the parts that are stable instead:
+//
+//	[<prefix>-]aerospike-server-<edition> <sep> <version>[<sep><release>] <osTag> <sep> <arch> . <ext>
+//
+// The OS tag ("ubuntu24.04", "el9", "amzn2023", "debian12") is the anchor:
+// version/release sit before it, the architecture after it, and everything in
+// between may use any of the separators the pipelines have used ("-", "_",
+// ".", "~", "+") or carry an extra build tag. Names without an OS tag, an
+// architecture or a numeric version are still rejected, which keeps container
+// images and source archives out.
 
-// rpm: [prefix-]aerospike-server-{edition}[-{tag}]-{version}-{release}.{osTag}.{arch}.rpm
-//
-//	aerospike-server-community-8.1.3.0-28.amzn2023.aarch64.rpm
-//	aerospike-aerospike-server-enterprise-TEST-8.1.3.0-36.ubuntu24.04.aarch64.rpm
-var rpmRE = regexp.MustCompile(
-	`^(?:.*?-)?aerospike-server-(community|enterprise|federal)` +
-		`(?:-[A-Za-z][A-Za-z0-9]*)*-` +
-		`([0-9][0-9.]*)-([0-9]+)\.` +
-		`((?:amzn|el|debian|ubuntu)[0-9]+(?:\.[0-9]+)?)\.` +
-		`(x86_64|aarch64)\.rpm$`,
-)
+// serverPrefixRE matches "[<prefix>-]aerospike-server-<edition>" at the head
+// of an artifact name; submatch 1 is the edition.
+var serverPrefixRE = regexp.MustCompile(
+	`^(?:.*?-)?aerospike-server-(community|enterprise|federal)(?:[^a-z]|$)`)
 
-// deb: [prefix-]aerospike-server-{edition}[-{tag}]_{version}-{release}{osTag}_{arch}.deb
-//
-//	aerospike-server-community_8.1.3.0-28debian12_amd64.deb
-//	aerospike-server-enterprise_8.1.3.0-28ubuntu24.04_arm64.deb
-//	aerospike-aerospike-server-enterprise-TEST_8.1.3.0-36ubuntu24.04_arm64.deb
-//
-// Note: there is no underscore between {release} and {osTag}.
-var debRE = regexp.MustCompile(
-	`^(?:.*?-)?aerospike-server-(community|enterprise|federal)` +
-		`(?:-[A-Za-z0-9]+)*_` +
-		`([0-9][0-9.]*)-([0-9]+)` +
-		`((?:amzn|el|debian|ubuntu)[0-9]+(?:\.[0-9]+)?)` +
-		`_(amd64|arm64)\.deb$`,
-)
+// toolsPrefixRE is the aerospike-tools equivalent of serverPrefixRE.
+var toolsPrefixRE = regexp.MustCompile(`^(?:.*?-)?(aerospike-tools)(?:[^a-z]|$)`)
+
+// osTagRE matches a JFrog OS tag. No delimiter is required in front of it:
+// the deb layout runs the release straight into the tag
+// ("…-28ubuntu24.04_amd64.deb", "…-70-g282a6817dubuntu24.04_amd64.deb"), so
+// the last occurrence in the name is taken instead.
+var osTagRE = regexp.MustCompile(`((?:amzn|debian|ubuntu|el)[0-9]+(?:\.[0-9]+)?)`)
+
+// archRE matches an architecture token delimited by separators or ends of
+// string. Both the rpm/tgz vocabulary (x86_64/aarch64) and the deb one
+// (amd64/arm64) are accepted; debArch normalises them.
+var archRE = regexp.MustCompile(`(?:^|[^A-Za-z0-9])(x86_64|aarch64|amd64|arm64)(?:[^A-Za-z0-9]|$)`)
+
+// versionRE matches the first separator-delimited numeric version run, so a
+// leading build tag ("-TEST_8.1.3.0-36…") does not get mistaken for one.
+var versionRE = regexp.MustCompile(`(?:^|[^A-Za-z0-9])([0-9]+(?:\.[0-9]+)*)`)
 
 // ToolsParts is the parsed form of an "aerospike-tools_*.tgz" artifact.
 // The tools bundle (asinfo, asadm, aql, …) is edition-agnostic, so unlike
@@ -65,65 +71,145 @@ type ToolsParts struct {
 	Arch      string // x86_64 | aarch64
 }
 
-// tools: [prefix-]aerospike-tools_{version}_{osTag}_{arch}.tgz
-//
-//	aerospike-tools_11.2.2_ubuntu24.04_aarch64.tgz
-//	aerospike-tools_11.2.2_ubuntu24.04_x86_64.tgz
-//	aerospike-tools_11.2.2_amzn2023_x86_64.tgz
-//
-// The optional prefix mirrors the server parser so double-prefixed CI
-// names (e.g. "aerospike-aerospike-tools_...") still match.
-var toolsRE = regexp.MustCompile(
-	`^(?:.*?-)?aerospike-tools_` +
-		`([0-9][0-9.]*)_` +
-		`((?:amzn|el|debian|ubuntu)[0-9]+(?:\.[0-9]+)?)_` +
-		`(x86_64|aarch64)\.tgz$`,
-)
-
 // ParseToolsFileName returns the parsed ToolsParts, or nil if the name is
 // not an Aerospike tools .tgz.
+//
+//	aerospike-tools_11.2.2_ubuntu24.04_x86_64.tgz
+//	aerospike-aerospike-tools_11.2.2-1_amzn2023_aarch64.tgz
 func ParseToolsFileName(name string) *ToolsParts {
-	m := toolsRE.FindStringSubmatch(name)
+	base, format := splitPackageExt(name)
+	if format != "tgz" {
+		return nil
+	}
+	m := toolsPrefixRE.FindStringSubmatchIndex(base)
 	if m == nil {
 		return nil
 	}
-	os, ver := splitOSTag(m[2])
+	p := parseTail(base[m[3]:])
+	if p == nil {
+		return nil
+	}
 	return &ToolsParts{
-		Version:   m[1],
-		OSName:    os,
-		OSVersion: ver,
-		Arch:      m[3],
+		Version:   p.version,
+		OSName:    p.osName,
+		OSVersion: p.osVersion,
+		Arch:      p.arch,
 	}
 }
 
 // ParseFileName returns the parsed NameParts, or nil if the name does not
-// match an Aerospike server RPM or DEB.
+// match an Aerospike server RPM, DEB or .tgz bundle.
+//
+//	aerospike-server-community-8.1.3.0-28.amzn2023.aarch64.rpm
+//	aerospike-server-enterprise_8.1.3.0-28ubuntu24.04_arm64.deb
+//	aerospike-server-enterprise_8.1.3.0-70-g282a6817dubuntu24.04_amd64.deb
+//	aerospike-server-enterprise_8.0.0.8_ubuntu24.04_x86_64.tgz
 func ParseFileName(name string) *NameParts {
-	if m := rpmRE.FindStringSubmatch(name); m != nil {
-		os, ver := splitOSTag(m[4])
-		return &NameParts{
-			Edition:   m[1],
-			Version:   m[2],
-			Release:   m[3],
-			OSName:    os,
-			OSVersion: ver,
-			Arch:      m[5],
-			Format:    "rpm",
-		}
+	base, format := splitPackageExt(name)
+	if format == "" {
+		return nil
 	}
-	if m := debRE.FindStringSubmatch(name); m != nil {
-		os, ver := splitOSTag(m[4])
-		return &NameParts{
-			Edition:   m[1],
-			Version:   m[2],
-			Release:   m[3],
-			OSName:    os,
-			OSVersion: ver,
-			Arch:      debArch(m[5]),
-			Format:    "deb",
-		}
+	m := serverPrefixRE.FindStringSubmatchIndex(base)
+	if m == nil {
+		return nil
 	}
-	return nil
+	edition := base[m[2]:m[3]]
+	p := parseTail(base[m[3]:])
+	if p == nil {
+		return nil
+	}
+	return &NameParts{
+		Edition:   edition,
+		Version:   p.version,
+		Release:   p.release,
+		OSName:    p.osName,
+		OSVersion: p.osVersion,
+		Arch:      p.arch,
+		Format:    format,
+	}
+}
+
+// nameTail is the product-independent part of an artifact name: everything
+// after the "aerospike-server-<edition>" / "aerospike-tools" head.
+type nameTail struct {
+	version   string
+	release   string
+	osName    string
+	osVersion string
+	arch      string
+}
+
+// parseTail extracts version/release, OS and architecture from the tail of an
+// artifact name (extension already stripped). Returns nil when any of the
+// required tokens is missing.
+func parseTail(rest string) *nameTail {
+	os := lastSubmatch(osTagRE, rest)
+	if os == nil {
+		return nil
+	}
+	osName, osVersion := splitOSTag(rest[os[0]:os[1]])
+	if osName == "" {
+		return nil
+	}
+	// the architecture always trails the OS tag
+	after := rest[os[1]:]
+	arch := lastSubmatch(archRE, after)
+	if arch == nil {
+		return nil
+	}
+	version, release := splitVersionRelease(rest[:os[0]])
+	if version == "" {
+		return nil
+	}
+	return &nameTail{
+		version:   version,
+		release:   release,
+		osName:    osName,
+		osVersion: osVersion,
+		arch:      debArch(after[arch[0]:arch[1]]),
+	}
+}
+
+// lastSubmatch returns the [start,end) offsets of the LAST occurrence of
+// re's first capturing group in s, or nil when there is none. Taking the last
+// match keeps a version or path fragment that happens to look like a token
+// from shadowing the real one, which always sits at the end of the name.
+func lastSubmatch(re *regexp.Regexp, s string) []int {
+	all := re.FindAllStringSubmatchIndex(s, -1)
+	if len(all) == 0 {
+		return nil
+	}
+	m := all[len(all)-1]
+	return []int{m[2], m[3]}
+}
+
+// splitVersionRelease splits the "<version>[<sep><release>]" segment that
+// sits between the product name and the OS tag. The release is whatever
+// follows the version, stripped of separators, and may be empty (.tgz
+// bundles) or non-numeric ("70-g282a6817d" on git-describe builds).
+func splitVersionRelease(mid string) (version, release string) {
+	m := versionRE.FindStringSubmatchIndex(mid)
+	if m == nil {
+		return "", ""
+	}
+	return mid[m[2]:m[3]], strings.Trim(mid[m[3]:], "-_.~+")
+}
+
+// splitPackageExt strips a known package extension and returns the bare name
+// plus the install format. Signatures and checksums (".deb.asc",
+// ".rpm.sha256", …) do not end in a package extension and are rejected here.
+func splitPackageExt(name string) (base, format string) {
+	switch {
+	case strings.HasSuffix(name, ".deb"):
+		return strings.TrimSuffix(name, ".deb"), "deb"
+	case strings.HasSuffix(name, ".rpm"):
+		return strings.TrimSuffix(name, ".rpm"), "rpm"
+	case strings.HasSuffix(name, ".tgz"):
+		return strings.TrimSuffix(name, ".tgz"), "tgz"
+	case strings.HasSuffix(name, ".tar.gz"):
+		return strings.TrimSuffix(name, ".tar.gz"), "tgz"
+	}
+	return "", ""
 }
 
 // splitOSTag turns a JFrog osTag like "amzn2023" / "debian12" / "ubuntu24.04"

--- a/pkg/utils/installers/aerospike/jfrog/parser_test.go
+++ b/pkg/utils/installers/aerospike/jfrog/parser_test.go
@@ -63,6 +63,50 @@ func TestParseFileName_DEB(t *testing.T) {
 			"aerospike-aerospike-server-enterprise-TEST_8.1.3.0-36ubuntu24.04_arm64.deb",
 			NameParts{Edition: "enterprise", Version: "8.1.3.0", Release: "36", OSName: "ubuntu", OSVersion: "24.04", Arch: "aarch64", Format: "deb"},
 		},
+		// git-describe release field (dev builds), with and without a
+		// separator in front of the OS tag
+		{
+			"aerospike-server-enterprise_8.1.3.0-70-g282a6817dubuntu24.04_amd64.deb",
+			NameParts{Edition: "enterprise", Version: "8.1.3.0", Release: "70-g282a6817d", OSName: "ubuntu", OSVersion: "24.04", Arch: "x86_64", Format: "deb"},
+		},
+		{
+			"aerospike-server-enterprise_8.1.3.0-70-g282a6817d.ubuntu24.04_amd64.deb",
+			NameParts{Edition: "enterprise", Version: "8.1.3.0", Release: "70-g282a6817d", OSName: "ubuntu", OSVersion: "24.04", Arch: "x86_64", Format: "deb"},
+		},
+		{
+			"aerospike-server-enterprise_8.1.3.0~70~g282a6817d_ubuntu24.04_amd64.deb",
+			NameParts{Edition: "enterprise", Version: "8.1.3.0", Release: "70~g282a6817d", OSName: "ubuntu", OSVersion: "24.04", Arch: "x86_64", Format: "deb"},
+		},
+	}
+	for _, tc := range cases {
+		got := ParseFileName(tc.name)
+		if got == nil {
+			t.Errorf("%s: parse returned nil", tc.name)
+			continue
+		}
+		if *got != tc.want {
+			t.Errorf("%s:\n  got  %+v\n  want %+v", tc.name, *got, tc.want)
+		}
+	}
+}
+
+func TestParseFileName_TGZ(t *testing.T) {
+	cases := []struct {
+		name string
+		want NameParts
+	}{
+		{
+			"aerospike-server-enterprise_8.0.0.8_ubuntu24.04_x86_64.tgz",
+			NameParts{Edition: "enterprise", Version: "8.0.0.8", OSName: "ubuntu", OSVersion: "24.04", Arch: "x86_64", Format: "tgz"},
+		},
+		{
+			"aerospike-server-enterprise_8.0.0.8_tools-11.2.2_ubuntu24.04_x86_64.tgz",
+			NameParts{Edition: "enterprise", Version: "8.0.0.8", Release: "tools-11.2.2", OSName: "ubuntu", OSVersion: "24.04", Arch: "x86_64", Format: "tgz"},
+		},
+		{
+			"aerospike-server-community_8.1.3.0-70-g282a6817d_amzn2023_aarch64.tar.gz",
+			NameParts{Edition: "community", Version: "8.1.3.0", Release: "70-g282a6817d", OSName: "amazon", OSVersion: "2023", Arch: "aarch64", Format: "tgz"},
+		},
 	}
 	for _, tc := range cases {
 		got := ParseFileName(tc.name)
@@ -80,7 +124,9 @@ func TestParseFileName_Ignored(t *testing.T) {
 	skip := []string{
 		"aerospike-server-community-8.1.3.0-28.amzn2023.aarch64.rpm.asc",
 		"aerospike-server-community_8.1.3.0-28debian12_amd64.deb.asc",
-		"aerospike-server-enterprise_8.0.0.8_ubuntu24.04_x86_64.tgz", // public-download style
+		"aerospike-server-enterprise_8.0.0.8_ubuntu24.04_x86_64.tgz.sha256",
+		"aerospike-server-enterprise_8.1.3.0_source.tar.gz", // no OS tag / arch
+		"aerospike-server-enterprise-docker_8.1.3.0_x86_64.tgz",
 		"aerospike-tools_11.2.2_ubuntu24.04_aarch64.tgz",
 		"random.txt",
 		"",

--- a/pkg/utils/installers/aerospike/jfrog/scripts.go
+++ b/pkg/utils/installers/aerospike/jfrog/scripts.go
@@ -52,6 +52,10 @@ func InstallScript(f *File, debug, upgrade bool) ([]byte, error) {
 		tplName = "scripts/install_server_rpm.sh.tpl"
 	case "deb":
 		tplName = "scripts/install_server_deb.sh.tpl"
+	case "tgz":
+		// self-contained bundle: extract and let asinstall lay down the
+		// deb/rpm it carries
+		tplName = "scripts/install_server_tgz.sh.tpl"
 	default:
 		return nil, fmt.Errorf("jfrog: unsupported install format %q", f.Parts.Format)
 	}

--- a/pkg/utils/installers/aerospike/jfrog/scripts/install_server_tgz.sh.tpl
+++ b/pkg/utils/installers/aerospike/jfrog/scripts/install_server_tgz.sh.tpl
@@ -1,0 +1,48 @@
+# shellcheck disable=SC2148
+UPGRADE="{{.Upgrade}}"
+if [ "$UPGRADE" != "true" ]; then
+    if command -v asd &> /dev/null; then
+        echo "Aerospike server is already installed"
+        exit 0
+    fi
+fi
+
+FILE_NAME="{{.FileName}}"
+
+if [ ! -f "$FILE_NAME" ]; then
+    echo "Package file $FILE_NAME not found"
+    exit 1
+fi
+
+fileDir=$(dirname "$FILE_NAME")
+pushd "$fileDir" || exit 1
+
+# get the top level directory name from the tar archive
+topDir=$(tar -tzf "$FILE_NAME" | head -1 | cut -f1 -d"/")
+if [ -z "$topDir" ]; then
+    echo "Could not determine top directory name from tar archive"
+    exit 1
+fi
+
+# extract the file
+tar -xzf "$FILE_NAME" || exit 1
+
+# check if the installer exists
+if [ ! -f "$topDir/asinstall" ]; then
+    echo "File $topDir/asinstall not found after attempting to extract"
+    exit 1
+fi
+
+# run the install script (installs the deb/rpm bundled in the archive)
+pushd "$topDir" || exit 1
+./asinstall || exit 1
+popd || exit 1
+
+# check if it installed successfully
+if ! command -v asd &> /dev/null; then
+    echo "Aerospike server is not installed after attempting to install"
+    exit 1
+fi
+
+# done
+popd || exit 1


### PR DESCRIPTION
Draft PR opened by **Tiger** (automated agent). Review before merging.

**Repo:** `aerolab`  
**Base:** `v8.0.0`

**Task:**
> Fixed parsing of enterprise server packages that use non-numeric releases or git-describe version strings (e.g., builds with `-70-g...` tags). Added .tgz bundles as a fallback installation source. Improved error messages to list artifacts on the build and diagnose three root causes: missing packages, restricted JFrog credentials, or distro-only repo paths.

**Tiger's summary:**

Fixed on `v8.0.0` — commit `80bc294a`, draft PR incoming.

**What your log actually said.** That error is the branch aerolab takes when **not one of the 180 artifacts parsed as an enterprise server package** — not "none for 24.04". If enterprise debs for *any* distro had parsed, you'd have gotten the other message listing candidates. And then aerolab threw the artifact list away, which is why there's nothing after it. That dead-end is a real defect, so I fixed it along with the two naming gaps that can produce it:

1. **Filename parsing is now tokenised around the OS tag** (`pkg/utils/installers/aerospike/jfrog/parser.go`) instead of one rigid regex per format. The old deb regex required a **purely numeric** release glued to the OS tag (`…_8.1.3.0-28ubuntu24.04_amd64.deb`), so a git-describe release like `8.1.3.0-70-g282a6817d…` — exactly the shape of your build — parsed as nothing. Any separator (`-`, `_`, `.`, `~`, `+`), a non-numeric release, a `-TEST` tag or a doubled `aerospike-` prefix now parse.

2. **`.tgz` server bundles are installable.** If that build publishes `aerospike-server-enterprise_<ver>_ubuntu24.04_x86_64.tgz` instead of loose debs, aerolab used to skip it outright (it was explicitly on the ignore list). It's now a fallback source — the native deb/rpm still wins when both exist — installed via extract + `./asinstall`, same as the tools bundle.

3. **The error is now self-diagnosing.** It lists up to 15 artifacts that *were* on the build (with their repo paths), the exact name shape it expects, and flags the third possibility: AQL silently omits repositories your token can't read, which looks identical to "the build has no EE packages".

New message shape:

```
jfrog: no enterprise deb (or .tgz bundle) package found for ubuntu/24.04/x86_64;
none of the 3 artifacts on this build parsed as an enterprise server package.
Expected a name such as aerospike-server-enterprise_<version>-<release>ubuntu24.04_amd64.deb
or aerospike-server-enterprise_<version>_ubuntu24.04_x86_64.tgz. If the build genuinely has
none, the package may live in a repository your JFrog credentials cannot read (AQL silently
omits those). Artifacts on the build: pool/noble/aerospike-server-enterprise_8.1.3.0-70_amd64.deb, ...
```

**Next step for you:** build aerolab from that branch (or the next v8 drop) and re-run your exact command. If it now resolves an artifact, you're unblocked. If it still fails, the error itself will contain the artifact names — paste that line and I'll know immediately which of the three causes it is (including the one case I deliberately didn't guess at: pipelines that put the distro only in the repo path, e.g. `pool/noble/`, and not in the filename).

**Verification a reviewer/you must do:** I have no JFrog credentials here, so parser + matcher changes are covered by unit tests only (`go build ./...`, `go vet`, `go test ./...` all pass). Untested against a live instance: that a real dev-build deb resolves, and that the new `.tgz` install path actually lands `asd`.
